### PR TITLE
Docs: update config template and README with peer URI query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,43 @@ name = "my-node"
 location = "datacenter-1"
 ```
 
+### Peer URI Query Parameters
+
+Both `peers` entries and `listen` addresses support optional query-string parameters:
+
+**Outbound peers** (`peers`):
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `password=PASSWORD` | Shared secret required to connect (max 64 chars, must match remote side) | `?password=secret` |
+| `key=PUBLICKEY` | Pin the expected public key (hex); connection fails if remote key differs | `?key=aabbcc...` |
+| `priority=N` | Connection priority (0–255, lower = higher priority) for path selection | `?priority=10` |
+| `maxbackoff=DURATION` | Maximum reconnect backoff interval if the peer goes down (min 5s, default 68m) | `?maxbackoff=30s` |
+| `sni=HOSTNAME` | Override TLS SNI hostname (TLS only; ignored for plain TCP) | `?sni=example.com` |
+
+**Inbound listeners** (`listen`):
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `password=PASSWORD` | Require this password from connecting peers (max 64 chars) | `?password=secret` |
+
+Duration values for `maxbackoff` accept plain seconds (`30`) or human-readable format (`30s`, `5m`, `1h`, `1h30m`).
+
+**Example with multiple parameters:**
+
+```toml
+peers = [
+    # VPS relay: faster reconnect, pinned key, TLS with custom SNI
+    "tls://relay.example.com:2096?maxbackoff=30s&key=aabbccdd...&sni=example.net",
+
+    # LAN node: higher priority than WAN peers
+    "tcp://192.168.1.10:12345?priority=10",
+
+    # Password-protected peer
+    "tcp://peer.example.com:12345?password=mysecret",
+]
+```
+
 ### Differences from Go Version
 
 **Command line:**
@@ -263,7 +300,7 @@ location = "datacenter-1"
 **Migration from Go config:**
 1. Convert HJSON/JSON to TOML format
 2. Rename all fields from PascalCase to snake_case
-3. Change transport URIs to TCP-only (remove `tls://`, `quic://`, etc.)
+3. Change transport URIs as needed (QUIC and WebSocket not yet supported — use `tcp://` or `tls://`)
 4. Update admin socket to TCP format if using Unix socket
 
 ## Crypto-Key Routing (CKR)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ This project aims to provide a lightweight, self-arranging, and secure mesh netw
 - Crypto-Key Routing (CKR) — tunnel arbitrary IPv4/IPv6 subnets through the mesh (`--features ckr`)
 
 **⏳ Planned Features:**
-- Additional transports: QUIC, WebSocket
 - Multicast peer discovery on local networks
 - Performance optimizations and protocol improvements
 
@@ -248,7 +247,7 @@ Both `peers` entries and `listen` addresses support optional query-string parame
 |-----------|-------------|---------|
 | `password=PASSWORD` | Shared secret required to connect (max 64 chars, must match remote side) | `?password=secret` |
 | `key=PUBLICKEY` | Pin the expected public key (hex); connection fails if remote key differs | `?key=aabbcc...` |
-| `priority=N` | Connection priority (0–255, lower = higher priority) for path selection | `?priority=10` |
+| `priority=N` | Connection priority (0-255, lower = higher priority) when multiple connections exist to the same peer | `?priority=10` |
 | `maxbackoff=DURATION` | Maximum reconnect backoff interval if the peer goes down (min 5s, default 68m) | `?maxbackoff=30s` |
 | `sni=HOSTNAME` | Override TLS SNI hostname (TLS only; ignored for plain TCP) | `?sni=example.com` |
 
@@ -294,13 +293,13 @@ peers = [
   - `node_info_privacy` instead of `NodeInfoPrivacy`
   - `allowed_public_keys` instead of `AllowedPublicKeys`
 - **Single binary**: Daemon and control tool are combined (no separate `yggdrasilctl`)
-- **Transport support**: TCP and TLS (QUIC, WebSocket coming later)
+- **Transport support**: TCP and TLS only
 - **Admin socket**: Defaults to TCP `localhost:9001` instead of Unix socket
 
 **Migration from Go config:**
 1. Convert HJSON/JSON to TOML format
 2. Rename all fields from PascalCase to snake_case
-3. Change transport URIs as needed (QUIC and WebSocket not yet supported — use `tcp://` or `tls://`)
+3. Change transport URIs as needed (QUIC and WebSocket are not supported — use `tcp://` or `tls://`)
 4. Update admin socket to TCP format if using Unix socket
 
 ## Crypto-Key Routing (CKR)

--- a/crates/yggdrasil/src/config_template.toml
+++ b/crates/yggdrasil/src/config_template.toml
@@ -8,20 +8,38 @@
 # Delete this line and restart to generate a new identity.
 private_key = "{{PRIVATE_KEY}}"
 
-# List of connection strings for outbound peer connections in URI format,
-# e.g. tcp://a.b.c.d:e, tls://a.b.c.d:e, quic://a.b.c.d:e, etc.
-# NOTE: Now Yggdrasil-ng supports only TCP connections.
+# List of connection strings for outbound peer connections in URI format.
+# Supported schemes: tcp://, tls://
 # You can find public peers at https://publicpeers.neilalexander.dev/
+#
+# Optional query parameters:
+#   key=HEX          - pin the remote peer's public key (connection fails if mismatch)
+#   password=SECRET  - shared password, must match the listener side (max 64 chars)
+#   priority=N       - connection priority 0–255, lower = preferred (default: 0)
+#   maxbackoff=DUR   - max reconnect wait if peer goes offline, e.g. 30s, 5m, 1h
+#                      (default: 4096s ≈ 68 min, minimum: 5s)
+#   sni=HOSTNAME     - override TLS SNI hostname, useful when connecting via IP
+#                      or through a reverse proxy (TLS only)
+#
+# Examples:
+#   "tcp://192.0.2.1:12345"
+#   "tls://peer.example.com:443?maxbackoff=30s&key=abcdef01..."
+#   "tls://203.0.113.5:2096?sni=peer.example.com&password=s3cr3t"
 peers = []
 
 # Listen addresses for inbound connections. You'll need to add port
 # forwarding for these ports if you are behind a NAT/firewall.
-# e.g. tcp://[::]:12345, tls://[::]:12345
-# NOTE: Now Yggdrasil-ng supports only TCP connections.
+# Supported schemes: tcp://, tls://
+#
+# Optional query parameters:
+#   password=SECRET  - require a shared password from connecting peers (max 64 chars)
+#
+# Examples:
+#   "tcp://[::]:12345"
+#   "tls://[::]:443?password=s3cr3t"
 listen = ["tcp://0.0.0.0:0"]
 
 # Listen address for the admin socket.
-# This is used by yggdrasilctl to query and control the node.
 # Set to "" to disable the admin socket.
 admin_listen = "tcp://localhost:9001"
 
@@ -44,13 +62,20 @@ if_mtu = 65535
 # these public keys will be allowed to connect. Leave empty to allow all peers.
 # allowed_public_keys = []
 
-# Multicast peer discovery on local network.
-# Each entry matches network interfaces by glob pattern.
-# beacon: advertise this node on matching interfaces
-# listen: accept peer discoveries on matching interfaces
-# port: TLS listener port (0 = auto-assign)
-# priority: connection priority (0-255)
-# password: authentication password (must match on both sides)
+# Multicast peer discovery — automatically finds and connects to nearby nodes
+# on the local network without manual configuration.
+#
+# Each entry controls which network interfaces participate in discovery.
+# Multiple entries can be added to apply different settings per interface.
+#
+# filter   - glob pattern to match interface names, e.g. "eth*", "en*", "*" (default: "*")
+# beacon   - advertise this node's presence on matching interfaces (default: true)
+# listen   - connect to other nodes discovered on matching interfaces (default: true)
+# port     - TLS listener port for this interface, 0 = auto-assign (default: 0)
+# priority - connection priority for peers found on this interface,
+#            lower = preferred when the same peer is reachable via multiple paths (default: 0)
+# password - shared password for discovery; only nodes with the same password
+#            will discover each other on this interface (default: none)
 [[multicast_interfaces]]
 filter = "*"
 beacon = true

--- a/crates/yggdrasil/src/config_template.toml
+++ b/crates/yggdrasil/src/config_template.toml
@@ -15,7 +15,8 @@ private_key = "{{PRIVATE_KEY}}"
 # Optional query parameters:
 #   key=HEX          - pin the remote peer's public key (connection fails if mismatch)
 #   password=SECRET  - shared password, must match the listener side (max 64 chars)
-#   priority=N       - connection priority 0–255, lower = preferred (default: 0)
+#   priority=N       - connection priority 0-255, lower = preferred when multiple
+#                      connections exist to the same peer (default: 0)
 #   maxbackoff=DUR   - max reconnect wait if peer goes offline, e.g. 30s, 5m, 1h
 #                      (default: 4096s ≈ 68 min, minimum: 5s)
 #   sni=HOSTNAME     - override TLS SNI hostname, useful when connecting via IP
@@ -72,8 +73,8 @@ if_mtu = 65535
 # beacon   - advertise this node's presence on matching interfaces (default: true)
 # listen   - connect to other nodes discovered on matching interfaces (default: true)
 # port     - TLS listener port for this interface, 0 = auto-assign (default: 0)
-# priority - connection priority for peers found on this interface,
-#            lower = preferred when the same peer is reachable via multiple paths (default: 0)
+# priority - connection priority for peers found on this interface (0-255, lower = preferred),
+#            used when the same peer is reachable via multiple connections
 # password - shared password for discovery; only nodes with the same password
 #            will discover each other on this interface (default: none)
 [[multicast_interfaces]]


### PR DESCRIPTION
Fixes outdated comments in config_template.toml that incorrectly stated only TCP is supported. TLS works flawlessly.

Adds documentation for peer URI query parameters (`key`, `password`, `priority`, `maxbackoff`, `sni`) directly in the config template as inline comments for easy copy-paste, and in the README as a reference table. The `priority` parameter is not documented in the upstream yggdrasil-go configuration reference despite being present in their code.

Also fixes a contradictory line in "Migration from Go config" that told users to remove `tls://` URIs.