### PR TITLE
Support for a single configuration file to run multiple prefixes

### DIFF
--- a/crates/yggdrasil/src/config.rs
+++ b/crates/yggdrasil/src/config.rs
@@ -64,7 +64,7 @@ pub struct Config {
     pub listen: Vec<String>,
 
     /// Admin socket listen address, e.g. `"tcp://localhost:9001"`.
-    #[serde(default)]
+    #[serde(default = "default_admin_listen")]
     pub admin_listen: String,
 
     /// TUN interface name. "auto" for auto-name, "none" to disable.
@@ -182,6 +182,9 @@ impl Default for TunnelRoutingConfig {
             install_system_routes: true,
         }
     }
+}
+fn default_admin_listen() -> String {
+    "tcp://localhost:9001".to_string()
 }
 
 fn default_if_name() -> String {

--- a/crates/yggdrasil/src/config_template.toml
+++ b/crates/yggdrasil/src/config_template.toml
@@ -21,9 +21,9 @@ peers = []
 listen = ["tcp://0.0.0.0:0"]
 
 # Listen address for the admin socket.
-# This is used by yggdrasilctl to query and control the node.
-# Set to "" to disable the admin socket.
-admin_listen = "tcp://localhost:9001"
+# This is used by yggdrasil to query and control the node by default.
+# Uncomment the line below and set `admin_listen = ""` to disable the admin socket.
+# admin_listen = "tcp://localhost:9001"
 
 # Name of the TUN interface to use.
 # "auto" = automatically assign a name.


### PR DESCRIPTION
This minor change makes manual tests a bit easier, as it allows the same configuration file to be reused when running multiple instances across different network prefixes simultaneously, in cases where peers are added after the network has started or where multicast is used.