### PR TITLE
Addresses beginning with ‘!’ are for CKR tunnelling only, without system routes

### DIFF
--- a/crates/yggdrasil/src/ckr.rs
+++ b/crates/yggdrasil/src/ckr.rs
@@ -152,7 +152,8 @@ pub fn is_yggdrasil_destination(ip: IpAddr) -> bool {
 /// `(union of includes) \ (union of excludes)`.
 ///
 /// Excludes only apply within the same address family as the includes.
-/// Duplicate includes are tolerated; excludes outside any include are ignored.
+/// Duplicate includes are tolerated; excludes outside any include are still
+/// added to the CKR table (they become CKR-only routes with no system route).
 pub fn expand_cidrs(entries: &[String]) -> Result<Vec<IpNet>, String> {
     let mut v4_inc: Vec<IpNet> = Vec::new();
     let mut v6_inc: Vec<IpNet> = Vec::new();
@@ -178,11 +179,24 @@ pub fn expand_cidrs(entries: &[String]) -> Result<Vec<IpNet>, String> {
     }
 
     let mut out = Vec::new();
-    for inc in v4_inc {
-        out.extend(subtract_many(inc, &v4_exc));
+    for inc in &v4_inc {
+        out.extend(subtract_many(*inc, &v4_exc));
     }
-    for inc in v6_inc {
-        out.extend(subtract_many(inc, &v6_exc));
+    for inc in &v6_inc {
+        out.extend(subtract_many(*inc, &v6_exc));
+    }
+    // Ignored excludes (those that do not overlap any include) become CKR-only
+    // routes. They are added to the CKR table but will be skipped for system
+    // routes in install_routes/remove_routes.
+    for ex in v4_exc {
+        if !v4_inc.iter().any(|inc| inc.contains(&ex.addr()) || ex.contains(&inc.addr())) {
+            out.push(ex);
+        }
+    }
+    for ex in v6_exc {
+        if !v6_inc.iter().any(|inc| inc.contains(&ex.addr()) || ex.contains(&inc.addr())) {
+            out.push(ex);
+        }
     }
     Ok(out)
 }
@@ -279,11 +293,24 @@ pub fn install_routes(
     // Skip entries whose destination is this node itself — those are handled
     // by the OS's native routing and should not be steered into the TUN.
     let mut cidrs: Vec<IpNet> = Vec::new();
+    let mut no_system_cidrs: Vec<IpNet> = Vec::new();
+    for subnet_list in config.remote_subnets.values() {
+        for raw in subnet_list {
+            if let Some(rest) = raw.strip_prefix('!') {
+                if let Ok(p) = rest.trim().parse::<IpNet>() {
+                    no_system_cidrs.push(p.trunc());
+                }
+            }
+        }
+    }
     for (pubkey_hex, subnet_list) in &config.remote_subnets {
         if parse_pubkey(pubkey_hex).ok().as_ref() == Some(self_key) {
             continue;
         }
         for prefix in expand_cidrs(subnet_list)? {
+            if no_system_cidrs.contains(&prefix) {
+                continue;
+            }
             if !cidrs.contains(&prefix) {
                 cidrs.push(prefix);
             }
@@ -325,12 +352,25 @@ pub fn remove_routes(config: &TunnelRoutingConfig, tun_name: &str, self_key: &[u
     }
 
     let mut cidrs: Vec<IpNet> = Vec::new();
+    let mut no_system_cidrs: Vec<IpNet> = Vec::new();
+    for subnet_list in config.remote_subnets.values() {
+        for raw in subnet_list {
+            if let Some(rest) = raw.strip_prefix('!') {
+                if let Ok(p) = rest.trim().parse::<IpNet>() {
+                    no_system_cidrs.push(p.trunc());
+                }
+            }
+        }
+    }
     for (pubkey_hex, subnet_list) in &config.remote_subnets {
         if parse_pubkey(pubkey_hex).ok().as_ref() == Some(self_key) {
             continue;
         }
         if let Ok(expanded) = expand_cidrs(subnet_list) {
             for prefix in expanded {
+                if no_system_cidrs.contains(&prefix) {
+                    continue;
+                }
                 if !cidrs.contains(&prefix) {
                     cidrs.push(prefix);
                 }
@@ -620,7 +660,8 @@ mod tests {
     fn test_expand_cidrs_exclude_outside_include_ignored() {
         let entries = vec!["10.0.0.0/24".to_string(), "!192.168.0.0/16".to_string()];
         let out = expand_cidrs(&entries).unwrap();
-        assert_eq!(out, vec!["10.0.0.0/24".parse::<IpNet>().unwrap()]);
+        assert!(out.contains(&"10.0.0.0/24".parse::<IpNet>().unwrap()));
+        assert!(out.contains(&"192.168.0.0/16".parse::<IpNet>().unwrap()));
     }
 
     #[test]
@@ -685,5 +726,28 @@ mod tests {
         // /16 should come before /8 (more specific first)
         assert_eq!(ckr.v4_routes[0].prefix.prefix_len(), 16);
         assert_eq!(ckr.v4_routes[1].prefix.prefix_len(), 8);
+    }
+    
+    #[test]
+    fn test_bang_prefix_creates_ckr_without_system_route() {
+        // Lone "!" entry → CKR tunnel is created (get_public_key_for_address works)
+        // but it will be skipped by install_routes/remove_routes.
+        let mut subnets = HashMap::new();
+        subnets.insert(dummy_key_hex(), vec!["!10.5.0.1/32".to_string()]);
+        let ckr = CryptoKey::new(&make_config(subnets), &SELF_KEY).unwrap();
+        assert_eq!(ckr.v4_routes.len(), 1);
+        let addr: IpAddr = "10.5.0.1".parse().unwrap();
+        assert_eq!(ckr.get_public_key_for_address(addr), Some([0x01u8; 32]));
+
+        // Mixed case: normal entry + lone "!" entry on same key
+        let mut subnets2 = HashMap::new();
+        subnets2.insert(
+            dummy_key_hex(),
+            vec!["10.0.0.0/24".to_string(), "!192.168.1.0/24".to_string()],
+        );
+        let ckr2 = CryptoKey::new(&make_config(subnets2), &SELF_KEY).unwrap();
+        assert_eq!(ckr2.v4_routes.len(), 2); // both are present in CKR table
+        assert!(ckr2.get_public_key_for_address("10.0.0.5".parse().unwrap()).is_some());
+        assert!(ckr2.get_public_key_for_address("192.168.1.5".parse().unwrap()).is_some());
     }
 }

--- a/crates/yggdrasil/src/ckr.rs
+++ b/crates/yggdrasil/src/ckr.rs
@@ -7,6 +7,14 @@ use route_manager::RouteManager;
 use crate::address::{is_valid_address, is_valid_subnet};
 use crate::config::TunnelRoutingConfig;
 
+const INETV4_PREFIXES: &[&str] = &[
+    "0.0.0.0/5", "8.0.0.0/7", "11.0.0.0/8", "12.0.0.0/6", "16.0.0.0/4", "32.0.0.0/3", "64.0.0.0/2", "128.0.0.0/3",
+    "160.0.0.0/5", "168.0.0.0/6", "172.0.0.0/12", "172.32.0.0/11", "172.64.0.0/10", "172.128.0.0/9", "173.0.0.0/8", "174.0.0.0/7",
+    "176.0.0.0/4", "192.0.0.0/9", "192.128.0.0/11", "192.160.0.0/13", "192.169.0.0/16", "192.170.0.0/15", "192.172.0.0/14", "192.176.0.0/12",
+    "192.192.0.0/10", "193.0.0.0/8", "194.0.0.0/7", "196.0.0.0/6", "200.0.0.0/5", "208.0.0.0/4",
+];
+const INETV6_PREFIX: &str = "2000::/3";
+
 /// A single CKR route: CIDR prefix -> destination public key.
 struct Route {
     prefix: IpNet,
@@ -160,6 +168,29 @@ pub fn expand_cidrs(entries: &[String]) -> Result<Vec<IpNet>, String> {
     let mut v4_exc: Vec<IpNet> = Vec::new();
     let mut v6_exc: Vec<IpNet> = Vec::new();
 
+    // Shadow `entries` with an expanded list so the rest of this function
+    // (the existing for-loop, strip_prefix match, parse, inc/exc pushes,
+    // subtract_many, duplicate checks, and ignored-exclude CKR-only logic)
+    // remains completely untouched and continues to work exactly as tested.
+    let entries: Vec<String> = {
+        let mut expanded = Vec::new();
+        for raw in entries {
+            let trimmed = raw.trim();
+            if trimmed == "inetv4" {
+                expanded.extend(INETV4_PREFIXES.iter().map(|s| s.to_string()));
+            } else if trimmed == "!inetv4" {
+                expanded.extend(INETV4_PREFIXES.iter().map(|s| format!("!{}", s)));
+            } else if trimmed == "inetv6" {
+                expanded.push(INETV6_PREFIX.to_string());
+            } else if trimmed == "!inetv6" {
+                expanded.push(format!("!{}", INETV6_PREFIX));
+            } else {
+                expanded.push(raw.clone());
+            }
+        }
+        expanded
+    };
+
     for raw in entries {
         let (is_exclude, cidr_str) = match raw.strip_prefix('!') {
             Some(rest) => (true, rest.trim()),
@@ -296,6 +327,18 @@ pub fn install_routes(
     let mut no_system_cidrs: Vec<IpNet> = Vec::new();
     for subnet_list in config.remote_subnets.values() {
         for raw in subnet_list {
+            let trimmed = raw.trim();
+            if trimmed == "!inetv4" {
+                for p_str in INETV4_PREFIXES {
+                    if let Ok(p) = p_str.parse::<IpNet>() {
+                        no_system_cidrs.push(p.trunc());
+                    }
+                }
+            } else if trimmed == "!inetv6" {
+                if let Ok(p) = INETV6_PREFIX.parse::<IpNet>() {
+                    no_system_cidrs.push(p.trunc());
+                }
+            }
             if let Some(rest) = raw.strip_prefix('!') {
                 if let Ok(p) = rest.trim().parse::<IpNet>() {
                     no_system_cidrs.push(p.trunc());
@@ -355,6 +398,18 @@ pub fn remove_routes(config: &TunnelRoutingConfig, tun_name: &str, self_key: &[u
     let mut no_system_cidrs: Vec<IpNet> = Vec::new();
     for subnet_list in config.remote_subnets.values() {
         for raw in subnet_list {
+            let trimmed = raw.trim();
+            if trimmed == "!inetv4" {
+                for p_str in INETV4_PREFIXES {
+                    if let Ok(p) = p_str.parse::<IpNet>() {
+                        no_system_cidrs.push(p.trunc());
+                    }
+                }
+            } else if trimmed == "!inetv6" {
+                if let Ok(p) = INETV6_PREFIX.parse::<IpNet>() {
+                    no_system_cidrs.push(p.trunc());
+                }
+            }
             if let Some(rest) = raw.strip_prefix('!') {
                 if let Ok(p) = rest.trim().parse::<IpNet>() {
                     no_system_cidrs.push(p.trunc());
@@ -749,5 +804,46 @@ mod tests {
         assert_eq!(ckr2.v4_routes.len(), 2); // both are present in CKR table
         assert!(ckr2.get_public_key_for_address("10.0.0.5".parse().unwrap()).is_some());
         assert!(ckr2.get_public_key_for_address("192.168.1.5".parse().unwrap()).is_some());
+    }
+    #[test]
+    fn test_inetv4_keyword() {
+        let mut subnets = HashMap::new();
+        subnets.insert(dummy_key_hex(), vec!["inetv4".to_string()]);
+        let ckr = CryptoKey::new(&make_config(subnets), &SELF_KEY).unwrap();
+        assert_eq!(ckr.v4_routes.len(), 30);
+        assert!(ckr.get_public_key_for_address("8.8.8.8".parse().unwrap()).is_some());
+        assert!(ckr.get_public_key_for_address("1.1.1.1".parse().unwrap()).is_some());
+        assert!(ckr.get_public_key_for_address("192.168.1.1".parse().unwrap()).is_none());
+        assert!(ckr.get_public_key_for_address("10.0.0.1".parse().unwrap()).is_none());
+        assert!(ckr.get_public_key_for_address("172.16.0.1".parse().unwrap()).is_none());
+    }
+
+    #[test]
+    fn test_inetv6_keyword() {
+        let mut subnets = HashMap::new();
+        subnets.insert(dummy_key_hex(), vec!["inetv6".to_string()]);
+        let ckr = CryptoKey::new(&make_config(subnets), &SELF_KEY).unwrap();
+        assert_eq!(ckr.v6_routes.len(), 1);
+        assert_eq!(ckr.v6_routes[0].prefix, "2000::/3".parse::<IpNet>().unwrap());
+        assert!(ckr.get_public_key_for_address("2001:db8::1".parse().unwrap()).is_some());
+        assert!(ckr.get_public_key_for_address("2600::1".parse().unwrap()).is_some());
+    }
+
+    #[test]
+    fn test_bang_inetv4_creates_ckr_without_system_route() {
+        let mut subnets = HashMap::new();
+        subnets.insert(dummy_key_hex(), vec!["!inetv4".to_string()]);
+        let ckr = CryptoKey::new(&make_config(subnets), &SELF_KEY).unwrap();
+        assert_eq!(ckr.v4_routes.len(), 30);
+        assert!(ckr.get_public_key_for_address("8.8.8.8".parse().unwrap()).is_some());
+    }
+
+    #[test]
+    fn test_bang_inetv6_creates_ckr_without_system_route() {
+        let mut subnets = HashMap::new();
+        subnets.insert(dummy_key_hex(), vec!["!inetv6".to_string()]);
+        let ckr = CryptoKey::new(&make_config(subnets), &SELF_KEY).unwrap();
+        assert_eq!(ckr.v6_routes.len(), 1);
+        assert!(ckr.get_public_key_for_address("2001:4860:4860::8888".parse().unwrap()).is_some());
     }
 }

--- a/crates/yggdrasil/src/config.rs
+++ b/crates/yggdrasil/src/config.rs
@@ -164,6 +164,8 @@ pub struct TunnelRoutingConfig {
     /// A leading "!" on a CIDR creates a CKR tunnel but skips system route
     /// installation (e.g. for manual or automated routing with third-party app).
     /// Example: { "aabbcc...01": ["10.0.0.0/24", "!192.168.1.0/24"] }
+    /// "inetv4"/"!inetv4" may be used in place of the 30 global IPv4 prefixes;
+    /// "inetv6"/"!inetv6" may be used in place of "2000::/3".
     #[serde(default)]
     pub remote_subnets: HashMap<String, Vec<String>>,
 

--- a/crates/yggdrasil/src/config.rs
+++ b/crates/yggdrasil/src/config.rs
@@ -161,7 +161,9 @@ pub struct TunnelRoutingConfig {
     pub ipv4_address: String,
 
     /// Remote subnets: maps hex public key -> list of CIDRs.
-    /// Example: { "aabbcc...01": ["10.0.0.0/24", "192.168.1.0/24"] }
+    /// A leading "!" on a CIDR creates a CKR tunnel but skips system route
+    /// installation (e.g. for manual or automated routing with third-party app).
+    /// Example: { "aabbcc...01": ["10.0.0.0/24", "!192.168.1.0/24"] }
     #[serde(default)]
     pub remote_subnets: HashMap<String, Vec<String>>,
 

--- a/crates/yggdrasil/src/config_template.toml
+++ b/crates/yggdrasil/src/config_template.toml
@@ -94,6 +94,7 @@ listen = true
 # ipv4_address = "10.99.0.1/24"  # IPv4 address for the TUN (exit-node/VPN use)
 # [tunnel_routing.remote_subnets]
 # "peer_public_key_hex" = ["10.0.0.0/24", "!192.168.1.0/24"]  # "!" = CKR tunnel created, but no OS route installed
+# "inetv4"/"!inetv4" and "inetv6"/"!inetv6" are also supported
 
 # Built-in stateful firewall. Default policy when enabled: drop inbound
 # from the mesh unless it's a reply to outbound traffic, comes from a

--- a/crates/yggdrasil/src/config_template.toml
+++ b/crates/yggdrasil/src/config_template.toml
@@ -93,7 +93,7 @@ listen = true
 # yggdrasil_routing = true
 # ipv4_address = "10.99.0.1/24"  # IPv4 address for the TUN (exit-node/VPN use)
 # [tunnel_routing.remote_subnets]
-# "peer_public_key_hex" = ["10.0.0.0/24", "192.168.1.0/24"]
+# "peer_public_key_hex" = ["10.0.0.0/24", "!192.168.1.0/24"]  # "!" = CKR tunnel created, but no OS route installed
 
 # Built-in stateful firewall. Default policy when enabled: drop inbound
 # from the mesh unless it's a reply to outbound traffic, comes from a


### PR DESCRIPTION
This apparently insignificant change makes the use of custom routing lists a bit easier.

Nowadays, such lists often exceed 100 kilobytes. "0.0.0.0/1", "128.0.0.0/1", "::/1",  "8000::/1" are unsuitable for many users. Of course, there is the option "install_system_routes = false", but this is a radical measure that sometimes only complicates things. 

Maybe this modification will encourage somebody to implement the import of multiple IPv4 and IPv6 routing lists in a future Android version by specifying local text files and network links to text files containing route lists.