### PR TITLE
Ckr options

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Add a `[tunnel_routing]` section to your `yggdrasil.toml`:
 [tunnel_routing]
 enable = true
 yggdrasil_routing = true
-ipv4_address = "10.99.0.1/24"
+ip_addresses = ["10.99.0.1/24"]
 
 [tunnel_routing.remote_subnets]
 "peer_public_key_hex" = ["10.0.0.0/24", "192.168.1.0/24"]
@@ -330,7 +330,9 @@ ipv4_address = "10.99.0.1/24"
 |--------|------|-------------|
 | `enable` | bool | Enable/disable CKR |
 | `yggdrasil_routing` | bool | Also route standard Yggdrasil `0200::/7` traffic (default: true) |
-| `ipv4_address` | string | IPv4 address to assign to TUN in CIDR notation (e.g., `"10.99.0.1/24"`) |
+| `install_system_routes` | bool | Automatically install system routing table entries for CKR. (default: true) |
+| `ipv4_address` | string | IPv4 address to assign to TUN in CIDR notation (e.g., `"10.99.0.1/24"`). Deprecated |
+| `ip_addresses` | array | IP addresses to assign to TUN in CIDR notation (e.g.,`[ "10.99.0.1/24", "2005:8a:9:11::3/64" ]`) |
 | `remote_subnets` | table | Maps hex public key to list of CIDRs to route via that node |
 
 System routes for all configured CIDRs are automatically installed when the TUN device starts and removed on shutdown. This works on Linux, Windows, and macOS.
@@ -347,7 +349,7 @@ Both nodes must be peered (directly or through the mesh) and built with `--featu
 [tunnel_routing]
 enable = true
 yggdrasil_routing = true
-ipv4_address = "10.99.0.2/24"
+ip_addresses = ["10.99.0.2/24"]
 
 [tunnel_routing.remote_subnets]
 # Route all IPv4 and IPv6 internet traffic via VPS
@@ -365,7 +367,7 @@ The `0.0.0.0/1` + `128.0.0.0/1` split covers all IPv4 without overriding the sys
 [tunnel_routing]
 enable = true
 yggdrasil_routing = true
-ipv4_address = "10.99.0.1/24"
+ip_addresses = ["10.99.0.1/24"]
 
 [tunnel_routing.remote_subnets]
 # Accept traffic from client's CKR subnet
@@ -403,33 +405,33 @@ curl ifconfig.me          # Should show VPS IPv4 address
 curl -6 ifconfig.me       # Should show VPS IPv6 address
 ```
 
-### Site-to-Site Tunnel
+### Dual-stack Site-to-Site Tunnel
 
-CKR can also connect two private networks. For example, to link `192.168.1.0/24` (Site A) with `192.168.2.0/24` (Site B):
+CKR can also connect two private networks. For example, to link `192.168.1.0/24` / `fd0a:1:1:1::1/64` (Site A) with `192.168.2.0/24` / `fd0a:1:1:2::1/64` (Site B): 
 
 **Site A:**
 ```toml
 [tunnel_routing]
 enable = true
-ipv4_address = "192.168.1.1/24"
+ip_addresses = ["192.168.1.1/24", "fd0a:1:1:1::1/64"]
 
 [tunnel_routing.remote_subnets]
-"<SITE_B_KEY>" = ["192.168.2.0/32"]
+"<SITE_B_KEY>" = ["192.168.2.0/32", "fd0a:1:1:2::1/128"]
 ```
 
 **Site B:**
 ```toml
 [tunnel_routing]
 enable = true
-ipv4_address = "192.168.2.1/24"
+ip_addresses = ["192.168.2.1/24", "fd0a:1:1:2::1/64"]
 
 [tunnel_routing.remote_subnets]
-"<SITE_A_KEY>" = ["192.168.1.0/32"]
+"<SITE_A_KEY>" = ["192.168.1.0/32", "fd0a:1:1:1::1/128"]
 ```
 
 Hosts on each side can then reach the other network through their Yggdrasil gateway node.
 
-### Private VPN (Multi-Node)
+### Private IPv4 VPN (Multi-Node)
 
 CKR can create a virtual private network where multiple nodes share a common IPv4 subnet and communicate directly over private IPs.
 Each node gets an address from the shared range (e.g., `10.99.0.0/24`) and has CKR routes pointing to every other node.
@@ -438,7 +440,7 @@ Each node gets an address from the shared range (e.g., `10.99.0.0/24`) and has C
 ```toml
 [tunnel_routing]
 enable = true
-ipv4_address = "10.99.0.1/24"
+ip_addresses = ["10.99.0.1/24"]
 
 [tunnel_routing.remote_subnets]
 "<NODE_B_KEY>" = ["10.99.0.2/32"]
@@ -449,7 +451,7 @@ ipv4_address = "10.99.0.1/24"
 ```toml
 [tunnel_routing]
 enable = true
-ipv4_address = "10.99.0.2/24"
+ip_addresses = ["10.99.0.2/24"]
 
 [tunnel_routing.remote_subnets]
 "<NODE_A_KEY>" = ["10.99.0.1/32"]
@@ -460,7 +462,7 @@ ipv4_address = "10.99.0.2/24"
 ```toml
 [tunnel_routing]
 enable = true
-ipv4_address = "10.99.0.3/24"
+ip_addresses = ["10.99.0.3/24"]
 
 [tunnel_routing.remote_subnets]
 "<NODE_A_KEY>" = ["10.99.0.1/32"]

--- a/README.md
+++ b/README.md
@@ -337,6 +337,13 @@ ip_addresses = ["10.99.0.1/24"]
 
 System routes for all configured CIDRs are automatically installed when the TUN device starts and removed on shutdown. This works on Linux, Windows, and macOS.
 
+The list of CIDRs for each public key supports additional syntax when the ckr feature is enabled:
+
+Prefix an IPv4 or IPv6 address/subnet with "~" (e.g. "~0.0.0.0/1", "~10.0.0.0/8", "~2000::/3") to establish CKR tunnels without installing system routes for those prefixes.
+Use "inetv4" to include the full list of IPv4 internet prefixes (excluding internal networks) for both CKR and system routes; use "~inetv4" for CKR tunnels only without system routes.
+Use "inetv6" or "~inetv6" similarly for IPv6 (expands to "2000::/3").
+The "!" prefix for exclusions applies to CKR ranges for both normal and "~" prefixed includes. No "!inetv4" or "!inetv6" are supported.
+
 ### Exit-Node Setup
 
 This example shows how to route all internet traffic from a client through a VPS running Yggdrasil-ng with CKR.

--- a/README.md
+++ b/README.md
@@ -337,12 +337,12 @@ ip_addresses = ["10.99.0.1/24"]
 
 System routes for all configured CIDRs are automatically installed when the TUN device starts and removed on shutdown. This works on Linux, Windows, and macOS.
 
-The list of CIDRs for each public key supports additional syntax when the ckr feature is enabled:
+The list of CIDRs for each public key supports additional syntax when the ckr feature is enabled (bare IPv4/IPv6 addresses without a subnet prefix are recognised as /32 and /128 respectively; this also applies to addresses beginning with "\~" and "!"):
 
-Prefix an IPv4 or IPv6 address/subnet with "~" (e.g. "~0.0.0.0/1", "~10.0.0.0/8", "~2000::/3") to establish CKR tunnels without installing system routes for those prefixes.
-Use "inetv4" to include the full list of IPv4 internet prefixes (excluding internal networks) for both CKR and system routes; use "~inetv4" for CKR tunnels only without system routes.
-Use "inetv6" or "~inetv6" similarly for IPv6 (expands to "2000::/3").
-The "!" prefix for exclusions applies to CKR ranges for both normal and "~" prefixed includes. No "!inetv4" or "!inetv6" are supported.
+Prefix an IPv4 or IPv6 address/subnet with "\~" (e.g. "\~0.0.0.0/1", "\~10.0.0.0/8", "\~2000::/3") to establish CKR tunnels without installing system routes for those prefixes.
+Use "inetv4" to include the full list of IPv4 internet prefixes (excluding internal networks) for both CKR and system routes; use "\~inetv4" for CKR tunnels only without system routes.
+Use "inetv6" or "\~inetv6" similarly for IPv6 (expands to "2000::/3").
+The "!" prefix for exclusions applies to CKR ranges for both normal and "\~" prefixed includes. No "!inetv4" or "!inetv6" are supported.
 
 ### Exit-Node Setup
 

--- a/crates/yggdrasil/src/ckr.rs
+++ b/crates/yggdrasil/src/ckr.rs
@@ -376,6 +376,7 @@ mod tests {
             enable: true,
             yggdrasil_routing: true,
             ipv4_address: String::new(),
+            ip_addresses: Vec::new(),
             remote_subnets: subnets,
             install_system_routes: true,
         }
@@ -410,6 +411,7 @@ mod tests {
             enable: false,
             yggdrasil_routing: true,
             ipv4_address: String::new(),
+            ip_addresses: Vec::new(),
             remote_subnets: subnets,
             install_system_routes: true,
         };
@@ -685,5 +687,20 @@ mod tests {
         // /16 should come before /8 (more specific first)
         assert_eq!(ckr.v4_routes[0].prefix.prefix_len(), 16);
         assert_eq!(ckr.v4_routes[1].prefix.prefix_len(), 8);
+    }
+
+    #[test]
+    fn test_ip_addresses_field_in_config() {
+        let config = TunnelRoutingConfig {
+            enable: true,
+            yggdrasil_routing: true,
+            ipv4_address: String::new(),
+            ip_addresses: vec!["10.99.0.1/24".to_string(), "2005:8a:9:11::3/64".to_string()],
+            remote_subnets: HashMap::new(),
+            install_system_routes: true,
+        };
+        let ckr = CryptoKey::new(&config, &SELF_KEY).unwrap();
+        assert!(ckr.v4_routes.is_empty());
+        assert!(ckr.v6_routes.is_empty());
     }
 }

--- a/crates/yggdrasil/src/ckr.rs
+++ b/crates/yggdrasil/src/ckr.rs
@@ -7,6 +7,15 @@ use route_manager::RouteManager;
 use crate::address::{is_valid_address, is_valid_subnet};
 use crate::config::TunnelRoutingConfig;
 
+const INETV4_PREFIXES: &[&str] = &[
+    "0.0.0.0/5", "8.0.0.0/7", "11.0.0.0/8", "12.0.0.0/6", "16.0.0.0/4", "32.0.0.0/3", "64.0.0.0/2", "128.0.0.0/3",
+    "160.0.0.0/5", "168.0.0.0/6", "172.0.0.0/12", "172.32.0.0/11", "172.64.0.0/10", "172.128.0.0/9", "173.0.0.0/8", "174.0.0.0/7",
+    "176.0.0.0/4", "192.0.0.0/9", "192.128.0.0/11", "192.160.0.0/13", "192.169.0.0/16", "192.170.0.0/15", "192.172.0.0/14", "192.176.0.0/12",
+    "192.192.0.0/10", "193.0.0.0/8", "194.0.0.0/7", "196.0.0.0/6", "200.0.0.0/5", "208.0.0.0/4"
+];
+
+const INETV6_PREFIXES: &[&str] = &["2000::/3"];
+
 /// A single CKR route: CIDR prefix -> destination public key.
 struct Route {
     prefix: IpNet,
@@ -159,10 +168,17 @@ pub fn expand_cidrs(entries: &[String]) -> Result<Vec<IpNet>, String> {
     let mut v4_exc: Vec<IpNet> = Vec::new();
     let mut v6_exc: Vec<IpNet> = Vec::new();
 
-    for raw in entries {
-        let (is_exclude, cidr_str) = match raw.strip_prefix('!') {
+    let normalized = normalize_subnet_entries(entries);
+    for raw in &normalized {
+        let trimmed = raw.trim();
+        let cidr_input = if let Some(after_tilde) = trimmed.strip_prefix('~') {
+            after_tilde.trim()
+        } else {
+            trimmed
+        };
+        let (is_exclude, cidr_str) = match cidr_input.strip_prefix('!') {
             Some(rest) => (true, rest.trim()),
-            None => (false, raw.as_str()),
+            None => (false, cidr_input),
         };
         let prefix: IpNet = cidr_str
             .parse()
@@ -238,6 +254,21 @@ fn subtract_one(a: IpNet, b: IpNet) -> Vec<IpNet> {
     result
 }
 
+fn normalize_subnet_entries(entries: &[String]) -> Vec<String> {
+    let mut normalized = Vec::new();
+    for entry in entries {
+        let trimmed = entry.trim();
+        match trimmed {
+            "inetv4" => normalized.extend(INETV4_PREFIXES.iter().map(|&s| s.to_string())),
+            "~inetv4" => normalized.extend(INETV4_PREFIXES.iter().map(|&s| format!("~{}", s))),
+            "inetv6" => normalized.extend(INETV6_PREFIXES.iter().map(|&s| s.to_string())),
+            "~inetv6" => normalized.extend(INETV6_PREFIXES.iter().map(|&s| format!("~{}", s))),
+            _ => normalized.push(trimmed.to_string()),
+        }
+    }
+    normalized
+}
+
 fn parse_pubkey(hex_str: &str) -> Result<[u8; 32], String> {
     let bytes =
         hex::decode(hex_str).map_err(|e| format!("invalid public key hex '{}': {}", hex_str, e))?;
@@ -283,7 +314,9 @@ pub fn install_routes(
         if parse_pubkey(pubkey_hex).ok().as_ref() == Some(self_key) {
             continue;
         }
-        for prefix in expand_cidrs(subnet_list)? {
+        let non_tilde_entries: Vec<String> = subnet_list.iter().filter(|s| !s.trim().starts_with('~')).cloned().collect();
+        let route_list = normalize_subnet_entries(&non_tilde_entries);
+        for prefix in expand_cidrs(&route_list)? {
             if !cidrs.contains(&prefix) {
                 cidrs.push(prefix);
             }
@@ -329,7 +362,9 @@ pub fn remove_routes(config: &TunnelRoutingConfig, tun_name: &str, self_key: &[u
         if parse_pubkey(pubkey_hex).ok().as_ref() == Some(self_key) {
             continue;
         }
-        if let Ok(expanded) = expand_cidrs(subnet_list) {
+        let non_tilde_entries: Vec<String> = subnet_list.iter().filter(|s| !s.trim().starts_with('~')).cloned().collect();
+        let route_list = normalize_subnet_entries(&non_tilde_entries);
+        if let Ok(expanded) = expand_cidrs(&route_list) {
             for prefix in expanded {
                 if !cidrs.contains(&prefix) {
                     cidrs.push(prefix);
@@ -702,5 +737,53 @@ mod tests {
         let ckr = CryptoKey::new(&config, &SELF_KEY).unwrap();
         assert!(ckr.v4_routes.is_empty());
         assert!(ckr.v6_routes.is_empty());
+    }
+
+    #[test]
+    fn test_expand_cidrs_inetv4_keyword() {
+        let entries = vec!["inetv4".to_string()];
+        let out = expand_cidrs(&entries).unwrap();
+        assert!(out.contains(&"0.0.0.0/5".parse::<IpNet>().unwrap()));
+        assert!(out.contains(&"208.0.0.0/4".parse::<IpNet>().unwrap()));
+        assert_eq!(out.len(), 30);
+    }
+
+    #[test]
+    fn test_expand_cidrs_tilde_inetv4_keyword() {
+        let entries = vec!["~inetv4".to_string()];
+        let out = expand_cidrs(&entries).unwrap();
+        assert!(out.contains(&"0.0.0.0/5".parse::<IpNet>().unwrap()));
+        assert_eq!(out.len(), 30);
+    }
+
+    #[test]
+    fn test_expand_cidrs_inetv6_keyword() {
+        let entries = vec!["inetv6".to_string()];
+        let out = expand_cidrs(&entries).unwrap();
+        assert!(out.contains(&"2000::/3".parse::<IpNet>().unwrap()));
+    }
+
+    #[test]
+    fn test_expand_cidrs_tilde_prefix() {
+        let entries = vec!["~10.0.0.0/24".to_string()];
+        let out = expand_cidrs(&entries).unwrap();
+        assert_eq!(out, vec!["10.0.0.0/24".parse::<IpNet>().unwrap()]);
+    }
+
+    #[test]
+    fn test_expand_cidrs_tilde_with_exclude() {
+        let entries = vec!["~0.0.0.0/0".to_string(), "!192.168.0.0/16".to_string()];
+        let out = expand_cidrs(&entries).unwrap();
+        let allowed: IpAddr = "8.8.8.8".parse().unwrap();
+        let blocked: IpAddr = "192.168.5.1".parse().unwrap();
+        assert!(out.iter().any(|n| n.contains(&allowed)));
+        assert!(!out.iter().any(|n| n.contains(&blocked)));
+    }
+
+    #[test]
+    fn test_expand_cidrs_exclude_applies_to_tilde() {
+        let entries = vec!["~10.0.0.0/24".to_string(), "!10.0.0.0/25".to_string()];
+        let out = expand_cidrs(&entries).unwrap();
+        assert_eq!(out, vec!["10.0.0.128/25".parse::<IpNet>().unwrap()]);
     }
 }

--- a/crates/yggdrasil/src/ckr.rs
+++ b/crates/yggdrasil/src/ckr.rs
@@ -180,7 +180,16 @@ pub fn expand_cidrs(entries: &[String]) -> Result<Vec<IpNet>, String> {
             Some(rest) => (true, rest.trim()),
             None => (false, cidr_input),
         };
-        let prefix: IpNet = cidr_str
+        let cidr_for_parse = if !cidr_str.contains('/') {
+            if cidr_str.contains(':') {
+                format!("{}/128", cidr_str)
+            } else {
+                format!("{}/32", cidr_str)
+            }
+        } else {
+            cidr_str.to_string()
+        };
+        let prefix: IpNet = cidr_for_parse
             .parse()
             .map_err(|e| format!("invalid CIDR '{}': {}", cidr_str, e))?;
         // Normalize to the network address (e.g. 10.0.0.5/24 -> 10.0.0.0/24).
@@ -457,7 +466,7 @@ mod tests {
     #[test]
     fn test_ipv4_route_lookup() {
         let mut subnets = HashMap::new();
-        subnets.insert(dummy_key_hex(), vec!["10.0.0.0/24".to_string()]);
+        subnets.insert(dummy_key_hex(), vec!["10.0.0.0/24".to_string(), "192.168.1.100".to_string()]);
         let ckr = CryptoKey::new(&make_config(subnets), &SELF_KEY).unwrap();
 
         let addr: IpAddr = "10.0.0.5".parse().unwrap();
@@ -466,6 +475,8 @@ mod tests {
 
         let miss: IpAddr = "192.168.0.1".parse().unwrap();
         assert_eq!(ckr.get_public_key_for_address(miss), None);
+        let bare_addr: IpAddr = "192.168.1.100".parse().unwrap();
+        assert_eq!(ckr.get_public_key_for_address(bare_addr), Some([0x01u8; 32]));
     }
 
     #[test]
@@ -473,7 +484,7 @@ mod tests {
         let mut subnets = HashMap::new();
         subnets.insert(
             dummy_key_hex(),
-            vec!["2001:db8::/32".to_string()],
+            vec!["2001:db8::/32".to_string(), "2001:db8:aaaa::1".to_string()],
         );
         let ckr = CryptoKey::new(&make_config(subnets), &SELF_KEY).unwrap();
 
@@ -482,6 +493,8 @@ mod tests {
 
         let miss: IpAddr = "2001:db9::1".parse().unwrap();
         assert_eq!(ckr.get_public_key_for_address(miss), None);
+        let bare_addr: IpAddr = "2001:db8:aaaa::1".parse().unwrap();
+        assert_eq!(ckr.get_public_key_for_address(bare_addr), Some([0x01u8; 32]));
     }
 
     #[test]
@@ -785,5 +798,25 @@ mod tests {
         let entries = vec!["~10.0.0.0/24".to_string(), "!10.0.0.0/25".to_string()];
         let out = expand_cidrs(&entries).unwrap();
         assert_eq!(out, vec!["10.0.0.128/25".parse::<IpNet>().unwrap()]);
+    }
+
+    #[test]
+    fn test_expand_cidrs_bare_ip_with_tilde_exclamation() {
+        let mut subnets = HashMap::new();
+        subnets.insert(
+            dummy_key_hex(),
+            vec!["10.0.0.0/24".to_string(), "!10.0.0.5".to_string(), "~192.168.1.100".to_string(), "2001:db8:bbbb::1".to_string()],
+        );
+        let ckr = CryptoKey::new(&make_config(subnets), &SELF_KEY).unwrap();
+
+        // bare IPv4 exclude applied
+        let excluded: IpAddr = "10.0.0.5".parse().unwrap();
+        assert_eq!(ckr.get_public_key_for_address(excluded), None);
+        // bare IPv4 with ~ still routed via CKR
+        let v4_bare: IpAddr = "192.168.1.100".parse().unwrap();
+        assert_eq!(ckr.get_public_key_for_address(v4_bare), Some([0x01u8; 32]));
+        // bare IPv6 routed via CKR
+        let v6_bare: IpAddr = "2001:db8:bbbb::1".parse().unwrap();
+        assert_eq!(ckr.get_public_key_for_address(v6_bare), Some([0x01u8; 32]));
     }
 }

--- a/crates/yggdrasil/src/config.rs
+++ b/crates/yggdrasil/src/config.rs
@@ -157,8 +157,19 @@ pub struct TunnelRoutingConfig {
     /// IPv4 address to assign to the TUN interface, in CIDR notation.
     /// Required for exit-node / VPN scenarios where IPv4 traffic is tunneled.
     /// Example: "10.99.0.1/24"
+    /// DEPRECATED: kept for backward compatibility; use `ip_addresses` 
+    /// for any number of IPv4/IPv6 addresses.
     #[serde(default)]
     pub ipv4_address: String,
+
+    /// Additional IP addresses (IPv4 or IPv6, in CIDR notation) to assign
+    /// to the TUN interface. Supports any number of addresses. New preferred
+    /// option for exit-node / VPN to replace deprecated ‘ipv4_address’.
+    /// Example: ["10.99.0.1/24", "2005:8a:9:11::3/64"]
+    /// The `ipv4_address` (if non-empty) is still assigned as the primary IPv4;
+    /// entries here are added alongside it.
+    #[serde(default)]
+    pub ip_addresses: Vec<String>,
 
     /// Remote subnets: maps hex public key -> list of CIDRs.
     /// Example: { "aabbcc...01": ["10.0.0.0/24", "192.168.1.0/24"] }
@@ -178,6 +189,7 @@ impl Default for TunnelRoutingConfig {
             enable: false,
             yggdrasil_routing: true,
             ipv4_address: String::new(),
+            ip_addresses: Vec::new(),
             remote_subnets: HashMap::new(),
             install_system_routes: true,
         }

--- a/crates/yggdrasil/src/config.rs
+++ b/crates/yggdrasil/src/config.rs
@@ -173,6 +173,12 @@ pub struct TunnelRoutingConfig {
 
     /// Remote subnets: maps hex public key -> list of CIDRs.
     /// Example: { "aabbcc...01": ["10.0.0.0/24", "192.168.1.0/24"] }
+    /// Supported syntax in the lists (when built with --features ckr):
+    /// - "CIDR" → CKR + system route
+    /// - "~CIDR" → CKR tunnel only (no system route)
+    /// - "!CIDR" → exclude from CKR (applies to both normal and ‘~’ entries)
+    /// - "inetv4" / "~inetv4" → full public IPv4 internet (excl. internals) +/– routes
+    /// - "inetv6" / "~inetv6" → 2000::/3 +/– routes
     #[serde(default)]
     pub remote_subnets: HashMap<String, Vec<String>>,
 

--- a/crates/yggdrasil/src/config.rs
+++ b/crates/yggdrasil/src/config.rs
@@ -162,21 +162,22 @@ pub struct TunnelRoutingConfig {
     #[serde(default)]
     pub ipv4_address: String,
 
-    /// Additional IP addresses (IPv4 or IPv6, in CIDR notation) to assign
+    /// Additional IP addresses (IPv4 or IPv6, in CIDR notation; 
+    /// prefix optional — IPv4 defaults to /32, IPv6 to /128) to assign
     /// to the TUN interface. Supports any number of addresses. New preferred
     /// option for exit-node / VPN to replace deprecated ‘ipv4_address’.
     /// Example: ["10.99.0.1/24", "2005:8a:9:11::3/64"]
-    /// The `ipv4_address` (if non-empty) is still assigned as the primary IPv4;
-    /// entries here are added alongside it.
     #[serde(default)]
     pub ip_addresses: Vec<String>,
 
-    /// Remote subnets: maps hex public key -> list of CIDRs.
+    /// Remote subnets: maps hex public key -> list of CIDRs (bare IP addresses 
+    /// without prefix are supported and treated as /32 for IPv4 or /128 for IPv6; 
+    /// this also applies to addresses beginning with "~" and "!").
     /// Example: { "aabbcc...01": ["10.0.0.0/24", "192.168.1.0/24"] }
     /// Supported syntax in the lists (when built with --features ckr):
-    /// - "CIDR" → CKR + system route
-    /// - "~CIDR" → CKR tunnel only (no system route)
-    /// - "!CIDR" → exclude from CKR (applies to both normal and ‘~’ entries)
+    /// - "CIDR" (or bare IP) → CKR + system route
+    /// - "~CIDR" (or ~bare IP) → CKR tunnel only (no system route)
+    /// - "!CIDR" (or !bare IP) → exclude from CKR (applies to both normal and ‘~’ entries)
     /// - "inetv4" / "~inetv4" → full public IPv4 internet (excl. internals) +/– routes
     /// - "inetv6" / "~inetv6" → 2000::/3 +/– routes
     #[serde(default)]

--- a/crates/yggdrasil/src/config_template.toml
+++ b/crates/yggdrasil/src/config_template.toml
@@ -91,9 +91,10 @@ listen = true
 # [tunnel_routing]
 # enable = true
 # yggdrasil_routing = true
-# ipv4_address = "10.99.0.1/24"  # IPv4 address for the TUN (exit-node/VPN use)
+# install_system_routes = true  # Automatically install system routing table entries for CKR.
+# ip_addresses = [ "10.99.0.1/24", "2005:8a:9:11::3/64" ]  # IPs for the TUN (VPN use) 
 # [tunnel_routing.remote_subnets]
-# "peer_public_key_hex" = ["10.0.0.0/24", "192.168.1.0/24"]
+# "peer_public_key_hex" = ["10.99.0.0/24", "192.168.1.0/24", "2005:8a:9:10::/64"]
 
 # Built-in stateful firewall. Default policy when enabled: drop inbound
 # from the mesh unless it's a reply to outbound traffic, comes from a

--- a/crates/yggdrasil/src/config_template.toml
+++ b/crates/yggdrasil/src/config_template.toml
@@ -88,6 +88,8 @@ listen = true
 
 # Crypto-Key Routing (CKR) — tunnel arbitrary IPv4/IPv6 subnets through
 # the Yggdrasil mesh. Requires the "ckr" feature to be enabled at build time.
+# Bare IPv4/IPv6 addresses without prefix are also accepted (/32 and /128 respectively; 
+# applies to ~ and ! prefixed entries too)
 # ‘~’ prefix means CKR tunnels without system routes. "inetv4"/"~inetv4" and 
 # "inetv6"/"~inetv6" expand to internet prefixes excluding internal networks. 
 # "!" excludes range from CKR, (e.g., "!142.250.109.0/24") for both normal 

--- a/crates/yggdrasil/src/config_template.toml
+++ b/crates/yggdrasil/src/config_template.toml
@@ -88,13 +88,17 @@ listen = true
 
 # Crypto-Key Routing (CKR) — tunnel arbitrary IPv4/IPv6 subnets through
 # the Yggdrasil mesh. Requires the "ckr" feature to be enabled at build time.
+# ‘~’ prefix means CKR tunnels without system routes. "inetv4"/"~inetv4" and 
+# "inetv6"/"~inetv6" expand to internet prefixes excluding internal networks. 
+# "!" excludes range from CKR, (e.g., "!142.250.109.0/24") for both normal 
+# and "~" prefixed includes. No "!inetv4" or "!inetv6" are supported.
 # [tunnel_routing]
 # enable = true
 # yggdrasil_routing = true
 # install_system_routes = true  # Automatically install system routing table entries for CKR.
 # ip_addresses = [ "10.99.0.1/24", "2005:8a:9:11::3/64" ]  # IPs for the TUN (VPN use) 
 # [tunnel_routing.remote_subnets]
-# "peer_public_key_hex" = ["10.99.0.0/24", "192.168.1.0/24", "2005:8a:9:10::/64"]
+# "peer_public_key_hex" = ["10.99.0.0/24", "fd03:1:2:3::/64", "~inetv4", "inetv6", "!172.16.0.0/12"]
 
 # Built-in stateful firewall. Default policy when enabled: drop inbound
 # from the mesh unless it's a reply to outbound traffic, comes from a

--- a/crates/yggdrasil/src/tun.rs
+++ b/crates/yggdrasil/src/tun.rs
@@ -72,6 +72,32 @@ impl TunAdapter {
             }
         }
 
+        // Assign IP addresses to TUN if configured in CKR
+        #[cfg(feature = "ckr")]
+        if let Some(ckr_cfg) = ckr_config {
+            for cidr in &ckr_cfg.ip_addresses {
+                if ckr_cfg.enable && !cidr.is_empty() {
+                    if cidr.contains(':') {
+                        // IPv6 path - reuse the same split/parse pattern already present 
+                        // in parse_ipv4_cidr and the existing Yggdrasil IPv6 handling above
+                        let parts: Vec<&str> = cidr.split('/').collect();
+                        if parts.len() == 2 {
+                            let ip_str = parts[0];
+                            let prefix: u8 = parts[1].parse().map_err(|e| format!("invalid IPv6 prefix in ip_addresses '{}': {}", cidr, e))?;
+                            let ip: Ipv6Addr = ip_str.parse().map_err(|e| format!("invalid IPv6 in ip_addresses '{}': {}", cidr, e))?;
+                            builder = builder.ipv6(ip, prefix);
+                            tracing::info!("CKR: assigning IPv6 address {} to TUN", cidr);
+                        }
+                    } else {
+                        // IPv4 path - reuse the exact existing parse_ipv4_cidr function
+                        let (v4_addr, v4_prefix) = parse_ipv4_cidr(cidr)?;
+                        builder = builder.ipv4(v4_addr, v4_prefix, None);
+                        tracing::info!("CKR: assigning IPv4 address {} to TUN", cidr);
+                    }
+                }
+            }
+        }
+
         #[cfg(windows)]
         {
             // Only call device_guid on Windows

--- a/crates/yggdrasil/src/tun.rs
+++ b/crates/yggdrasil/src/tun.rs
@@ -81,9 +81,13 @@ impl TunAdapter {
                         // IPv6 path - reuse the same split/parse pattern already present 
                         // in parse_ipv4_cidr and the existing Yggdrasil IPv6 handling above
                         let parts: Vec<&str> = cidr.split('/').collect();
-                        if parts.len() == 2 {
+                        if parts.len() == 1 || parts.len() == 2 {
                             let ip_str = parts[0];
-                            let prefix: u8 = parts[1].parse().map_err(|e| format!("invalid IPv6 prefix in ip_addresses '{}': {}", cidr, e))?;
+                            let prefix: u8 = if parts.len() == 1 {
+                                128
+                            } else {
+                                parts[1].parse().map_err(|e| format!("invalid IPv6 prefix in ip_addresses '{}': {}", cidr, e))?
+                            };
                             let ip: Ipv6Addr = ip_str.parse().map_err(|e| format!("invalid IPv6 in ip_addresses '{}': {}", cidr, e))?;
                             builder = builder.ipv6(ip, prefix);
                             tracing::info!("CKR: assigning IPv6 address {} to TUN", cidr);
@@ -207,15 +211,19 @@ async fn tun_write_loop(device: Arc<AsyncDevice>, rwc: Arc<ReadWriteCloser>) {
 #[cfg(feature = "ckr")]
 fn parse_ipv4_cidr(cidr: &str) -> Result<(Ipv4Addr, u8), String> {
     let parts: Vec<&str> = cidr.split('/').collect();
-    if parts.len() != 2 {
-        return Err(format!("invalid IPv4 CIDR '{}': expected addr/prefix", cidr));
-    }
-    let addr: Ipv4Addr = parts[0]
+    let (addr_str, prefix_str) = if parts.len() == 1 {
+        (parts[0], "32")
+    } else if parts.len() == 2 {
+        (parts[0], parts[1])
+    } else {
+        return Err(format!("invalid IPv4 CIDR '{}': expected addr or addr/prefix", cidr));
+    };
+    let addr: Ipv4Addr = addr_str
         .parse()
-        .map_err(|e| format!("invalid IPv4 address '{}': {}", parts[0], e))?;
-    let prefix: u8 = parts[1]
+        .map_err(|e| format!("invalid IPv4 address '{}': {}", addr_str, e))?;
+    let prefix: u8 = prefix_str
         .parse()
-        .map_err(|e| format!("invalid prefix length '{}': {}", parts[1], e))?;
+        .map_err(|e| format!("invalid prefix length '{}': {}", prefix_str, e))?;
     if prefix > 32 {
         return Err(format!("prefix length {} exceeds 32", prefix));
     }


### PR DESCRIPTION
Some minor changes to improve usability.
- Added the ability to specify multiple additional IP addresses for the TUN interface.
- Added the ability to route CKR for specific subnets without system routes using the ‘\~’ prefix.
- Added ‘inetv4’ and ‘inetv6’ aliases to forward only Internet subnets, excluding internal networks.
- Added the ability to specify IP addresses for TUN and CKR routes without specifying a prefix. Prefixes /32 for IPv4 and /128 for IPv6 are automatically assigned if no other prefix is specified.
