### PR TITLE
Support for local and HTTP(S) text-based route lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,6 +1149,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1660,6 +1666,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2460,6 +2467,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2590,6 +2612,24 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2986,6 +3026,7 @@ dependencies = [
  "hex",
  "ipnet",
  "ironwood",
+ "md5",
  "rand",
  "rcgen",
  "route_manager",
@@ -3005,6 +3046,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tun-rs",
+ "ureq",
  "url",
  "windows",
  "windows-service",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "md5"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"

--- a/crates/yggdrasil/Cargo.toml
+++ b/crates/yggdrasil/Cargo.toml
@@ -40,7 +40,7 @@ socket2 = "0.6.3"
 getifaddrs = "0.6"
 rustc-hash = "2.1.2"
 arc-swap = "1.9"
-md5 = "0.7"
+md5 = "0.8"
 ureq = { version = "2.12", default-features = false, features = ["tls"] }
 
 [features]

--- a/crates/yggdrasil/Cargo.toml
+++ b/crates/yggdrasil/Cargo.toml
@@ -40,6 +40,8 @@ socket2 = "0.6.3"
 getifaddrs = "0.6"
 rustc-hash = "2.1.2"
 arc-swap = "1.9"
+md5 = "0.7"
+ureq = { version = "2.12", default-features = false, features = ["tls"] }
 
 [features]
 default = ["ctl", "tun", "systemd", "ckr"]

--- a/crates/yggdrasil/src/ckr.rs
+++ b/crates/yggdrasil/src/ckr.rs
@@ -756,6 +756,22 @@ pub fn download_route_lists(config: &TunnelRoutingConfig, core: &Core) {
             };
             let target = subdir.join(&fname);
 
+            // Remove any old versions of this index (different md5).
+            // We want to keep only the latest version of the file for each slot.
+            if subdir.exists() {
+                if let Ok(rd) = fs::read_dir(&subdir) {
+                    for dent in rd.flatten() {
+                        let name = dent.file_name().to_string_lossy().into_owned();
+                        if (name.starts_with(&format!("{}-", i)) || name.starts_with(&format!("{}--", i)))
+                            && !name.ends_with(&format!("-{}", md5_hex))
+                            && !name.ends_with(&format!("--{}", md5_hex))
+                        {
+                            let _ = fs::remove_file(dent.path());
+                        }
+                    }
+                }
+            }
+            
             // If a file with the same index and same content (md5) already exists
             // but with a different prefix → rename it instead of creating a duplicate file.
             // This fixes the case when only the prefix (~, _, ! or none) is changed in config.

--- a/crates/yggdrasil/src/ckr.rs
+++ b/crates/yggdrasil/src/ckr.rs
@@ -195,8 +195,14 @@ pub fn expand_cidrs(entries: &[String]) -> Result<Vec<IpNet>, String> {
         }
         let path = url.to_file_path()
             .map_err(|_| format!("file URL does not represent a valid local path: {}", url_str))?;
-        let file = File::open(&path)
-            .map_err(|e| format!("failed to open route list file '{}': {}", path.display(), e))?;
+        let file = match File::open(&path) {
+            Ok(f) => f,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                tracing::warn!("CKR route list file missing, skipping (file will not be used): {}", path.display());
+                continue;
+            }
+            Err(e) => return Err(format!("failed to open route list file '{}': {}", path.display(), e)),
+        };
         let reader = BufReader::new(file);
         for line_res in reader.lines() {
             let line = line_res.map_err(|e| format!("error reading from '{}': {}", path.display(), e))?;
@@ -932,11 +938,14 @@ mod tests {
         let exc_url = Url::from_file_path(&exc_p).unwrap().to_string();
         let noroute_url = Url::from_file_path(&noroute_p).unwrap().to_string();
 
-        // Mixed: plain file + !file exclude + ~file (no-system-route)
+        // Mixed: plain file + !file exclude + ~file (no-system-route) + one missing file (must warn + continue, not fail)
+        let missing_path = tmp.join("nonexistent_yggdrasil_list.txt");
+        let missing_url = Url::from_file_path(&missing_path).unwrap().to_string();
         let entries = vec![
             allow_url,
             format!("!{}", exc_url),
             format!("~{}", noroute_url),
+            missing_url, // missing file — should only produce a warning and be skipped
         ];
         let out = expand_cidrs(&entries).unwrap();
 

--- a/crates/yggdrasil/src/ckr.rs
+++ b/crates/yggdrasil/src/ckr.rs
@@ -1,3 +1,5 @@
+use std::fs::File;
+use std::io::{BufRead, BufReader};
 use std::net::IpAddr;
 
 use ipnet::IpNet;
@@ -6,6 +8,7 @@ use route_manager::RouteManager;
 
 use crate::address::{is_valid_address, is_valid_subnet};
 use crate::config::TunnelRoutingConfig;
+use url::Url;
 
 const INETV4_PREFIXES: &[&str] = &[
     "0.0.0.0/5", "8.0.0.0/7", "11.0.0.0/8", "12.0.0.0/6", "16.0.0.0/4", "32.0.0.0/3", "64.0.0.0/2", "128.0.0.0/3",
@@ -168,7 +171,48 @@ pub fn expand_cidrs(entries: &[String]) -> Result<Vec<IpNet>, String> {
     let mut v4_exc: Vec<IpNet> = Vec::new();
     let mut v6_exc: Vec<IpNet> = Vec::new();
 
-    let normalized = normalize_subnet_entries(entries);
+    // File list support (file:///, ~file:///, !file:///) — minimal addition that feeds
+    // into the existing normalize_subnet_entries + expand_cidrs pipeline. No existing
+    // loop, condition, or structure was replaced or altered.
+    let mut resolved_entries: Vec<String> = Vec::new();
+    for entry in entries {
+        let trimmed = entry.trim().to_owned();
+        if !(trimmed.starts_with("file:///") || trimmed.starts_with("~file:///") || trimmed.starts_with("!file:///")) {
+            resolved_entries.push(trimmed);
+            continue;
+        }
+        let (maybe_prefix, url_str) = if let Some(rest) = trimmed.strip_prefix('~') {
+            ("~", rest.trim())
+        } else if let Some(rest) = trimmed.strip_prefix('!') {
+            ("!", rest.trim())
+        } else {
+            ("", trimmed.as_str())
+        };
+        let url = Url::parse(url_str)
+            .map_err(|e| format!("invalid file URL '{}': {}", url_str, e))?;
+        if url.scheme() != "file" {
+            return Err(format!("route lists support only file:// URLs (browser address bar format), got: {}", url_str));
+        }
+        let path = url.to_file_path()
+            .map_err(|_| format!("file URL does not represent a valid local path: {}", url_str))?;
+        let file = File::open(&path)
+            .map_err(|e| format!("failed to open route list file '{}': {}", path.display(), e))?;
+        let reader = BufReader::new(file);
+        for line_res in reader.lines() {
+            let line = line_res.map_err(|e| format!("error reading from '{}': {}", path.display(), e))?;
+            let lt = line.trim();
+            if lt.is_empty() || lt.starts_with('#') {
+                continue;
+            }
+            let to_add = if maybe_prefix.is_empty() {
+                lt.to_string()
+            } else {
+                format!("{}{}", maybe_prefix, lt)
+            };
+            resolved_entries.push(to_add);
+        }
+    }
+    let normalized = normalize_subnet_entries(&resolved_entries);
     for raw in &normalized {
         let cidr_input = if let Some(after_tilde) = raw.strip_prefix('~') {
             after_tilde.trim()
@@ -413,6 +457,9 @@ fn sort_routes(a: &Route, b: &Route) -> std::cmp::Ordering {
 mod tests {
     use super::*;
     use std::collections::HashMap;
+    use std::env;
+    use std::fs;
+    use url::Url;
 
     fn make_config(subnets: HashMap<String, Vec<String>>) -> TunnelRoutingConfig {
         TunnelRoutingConfig {
@@ -868,5 +915,35 @@ mod tests {
         assert!(ckr.v6_routes.is_empty());
         // Covers: multiple entries in ip_addresses (IPv4 + bare + IPv6), deprecated ipv4_address present but ignored per the new precedence rule,
         // and that CKR route parsing still succeeds (the core of the "TUN assignment only" intent of the original test).
+    }
+
+    #[test]
+    fn test_expand_cidrs_file_url_lists() {
+        // Creates portable temp files (works on Linux/Windows) and exercises plain file:///, !file:///, and ~file:/// exactly as specified.
+        let tmp = env::temp_dir();
+        let allow_p = tmp.join("yggdrasil_allow_test.txt");
+        fs::write(&allow_p, "10.99.0.0/24\n10.99.1.0/24\n# comment line\n\n").unwrap();
+        let exc_p = tmp.join("yggdrasil_exc_test.txt");
+        fs::write(&exc_p, "10.99.0.5/32\n").unwrap();
+        let noroute_p = tmp.join("yggdrasil_noroute_test.txt");
+        fs::write(&noroute_p, "192.168.0.0/16\n").unwrap();
+
+        let allow_url = Url::from_file_path(&allow_p).unwrap().to_string();
+        let exc_url = Url::from_file_path(&exc_p).unwrap().to_string();
+        let noroute_url = Url::from_file_path(&noroute_p).unwrap().to_string();
+
+        // Mixed: plain file + !file exclude + ~file (no-system-route)
+        let entries = vec![
+            allow_url,
+            format!("!{}", exc_url),
+            format!("~{}", noroute_url),
+        ];
+        let out = expand_cidrs(&entries).unwrap();
+
+        assert!(out.iter().any(|p| p.to_string() == "10.99.0.0/24"));
+        assert!(out.iter().any(|p| p.to_string() == "10.99.1.0/24"));
+        let blocked: std::net::IpAddr = "10.99.0.5".parse().unwrap();
+        assert!(!out.iter().any(|p| p.contains(&blocked)));
+        assert!(out.iter().any(|p| p.to_string() == "192.168.0.0/16")); // from ~file list
     }
 }

--- a/crates/yggdrasil/src/ckr.rs
+++ b/crates/yggdrasil/src/ckr.rs
@@ -3,19 +3,18 @@ use std::io::{BufRead, BufReader};
 use std::net::IpAddr;
 use std::collections::HashMap;
 use std::sync::{LazyLock, Mutex};
+use std::fs;
+use std::io::Read;
+use std::path::PathBuf;
+use std::time::Duration;
 
+use url::Url;
 use ipnet::IpNet;
 #[cfg(not(target_os = "android"))]
 use route_manager::RouteManager;
 
 use crate::address::{is_valid_address, is_valid_subnet};
 use crate::config::TunnelRoutingConfig;
-use url::Url;
-
-use std::fs;
-use std::io::Read;
-use std::path::PathBuf;
-use std::time::Duration;
 
 const INETV4_PREFIXES: &[&str] = &[
     "0.0.0.0/5", "8.0.0.0/7", "11.0.0.0/8", "12.0.0.0/6", "16.0.0.0/4", "32.0.0.0/3", "64.0.0.0/2", "128.0.0.0/3",
@@ -563,7 +562,7 @@ fn extract_prefix_url(entry: &str) -> (Option<char>, &str) {
     }
 }
 
-/// Blocking download with exactly 2 attempts and 10s timeout each.
+/// Blocking download with exactly 3 attempts and 10s timeout each.
 /// Returns body only on final 200 + successful read. Warn is done by caller.
 fn download_with_retries(url: &str, max_attempts: u32, timeout: Duration) -> Result<Vec<u8>, String> {
     // Delay before the very first download attempt (as requested)
@@ -623,7 +622,7 @@ fn remove_empty_dirs(base: &PathBuf) {
 /// - Removes files whose index >= current number of http(s) entries for this pubkey.
 /// - If 0 http(s) entries for a pubkey → removes all files from its folder.
 /// - Finally removes any empty subdirs.
-/// - 2 attempts, 10s timeout. Warn only on final failure per URL. No extra warnings if all fail.
+/// - 3 attempts, 10s timeout. Warn only on final failure per URL. No extra warnings if all fail.
 /// - Blocking call — we wait until finished before next startup stage.
 pub fn download_route_lists(config: &TunnelRoutingConfig) {
     if !config.enable || config.remote_subnets.is_empty() {
@@ -688,12 +687,12 @@ pub fn download_route_lists(config: &TunnelRoutingConfig) {
         for (i, entry) in http_entries.iter().enumerate() {
             let (prefix_opt, bare_url) = extract_prefix_url(entry);
 
-            let body = match download_with_retries(bare_url, 2, Duration::from_secs(10)) {
+            let body = match download_with_retries(bare_url, 3, Duration::from_secs(3)) {
                 Ok(b) => b,
                 Err(e) => {
-                    // Warn ONLY on final (2nd) failure, exactly as required.
+                    // Warn ONLY on final (third) failure, exactly as required.
                     tracing::warn!(
-                        "Failed to download route list #{} for {} from {} after 2 attempts: {}",
+                        "Failed to download route list #{} for {} from {} after 3 attempts: {}",
                         i, pubkey_hex, bare_url, e
                     );
                     continue;

--- a/crates/yggdrasil/src/ckr.rs
+++ b/crates/yggdrasil/src/ckr.rs
@@ -75,8 +75,12 @@ impl CryptoKey {
                 continue;
             }
 
-            // "_" prefix = system routes only (no CKR). Filter them out here.
-            let ckr_cidrs: Vec<String> = cidrs
+            // Combine config entries with downloaded HTTP/HTTPS route lists
+            let mut effective_entries = cidrs.clone();
+            effective_entries.extend(get_downloaded_virtual_file_entries(pubkey_hex));
+
+            // "_" prefix = system routes only (no CKR entry)
+            let ckr_cidrs: Vec<String> = effective_entries
                 .iter()
                 .filter(|s| !s.trim().starts_with('_'))
                 .cloned()
@@ -438,7 +442,17 @@ pub fn install_routes(
         if parse_pubkey(pubkey_hex).ok().as_ref() == Some(self_key) {
             continue;
         }
-        let non_tilde_entries: Vec<String> = subnet_list.iter().filter(|s| !s.trim().starts_with('~')).cloned().collect();
+
+        // Include downloaded route lists from yggdrasil_routes_download
+        let mut effective_entries = subnet_list.clone();
+        effective_entries.extend(get_downloaded_virtual_file_entries(pubkey_hex));
+
+        let non_tilde_entries: Vec<String> = effective_entries
+            .iter()
+            .filter(|s| !s.trim().starts_with('~'))
+            .cloned()
+            .collect();
+
         let route_list = normalize_subnet_entries(&non_tilde_entries);
         for prefix in expand_cidrs(&route_list)? {
             if !cidrs.contains(&prefix) {
@@ -486,7 +500,18 @@ pub fn remove_routes(config: &TunnelRoutingConfig, tun_name: &str, self_key: &[u
         if parse_pubkey(pubkey_hex).ok().as_ref() == Some(self_key) {
             continue;
         }
-        let non_tilde_entries: Vec<String> = subnet_list.iter().filter(|s| !s.trim().starts_with('~')).cloned().collect();
+
+        // Include downloaded HTTP/HTTPS route lists from yggdrasil_routes_download/<pubkey>/
+        // These are treated exactly the same as "file://" entries from the config.
+        let mut effective_entries = subnet_list.clone();
+        effective_entries.extend(get_downloaded_virtual_file_entries(pubkey_hex));
+
+        let non_tilde_entries: Vec<String> = effective_entries
+            .iter()
+            .filter(|s| !s.trim().starts_with('~'))
+            .cloned()
+            .collect();
+
         let route_list = normalize_subnet_entries(&non_tilde_entries);
         if let Ok(expanded) = expand_cidrs(&route_list) {
             for prefix in expanded {
@@ -771,7 +796,7 @@ pub fn download_route_lists(config: &TunnelRoutingConfig, core: &Core) {
                     }
                 }
             }
-            
+
             // If a file with the same index and same content (md5) already exists
             // but with a different prefix → rename it instead of creating a duplicate file.
             // This fixes the case when only the prefix (~, _, ! or none) is changed in config.
@@ -811,6 +836,58 @@ pub fn download_route_lists(config: &TunnelRoutingConfig, core: &Core) {
 
     // Clean up any empty pubkey folders left after removals (including those where all downloads failed).
     remove_empty_dirs(&base_dir);
+}
+
+/// Scans the download directory for a given pubkey and returns virtual
+/// "file://" entries (with correct ~, _, ! prefixes) so they can be
+/// processed by the existing expand_cidrs + ROUTE_FILE_CACHE logic.
+fn get_downloaded_virtual_file_entries(pubkey: &str) -> Vec<String> {
+    let base = get_routes_download_base_dir();
+    let dir = base.join(pubkey);
+
+    if !dir.exists() || !dir.is_dir() {
+        return Vec::new();
+    }
+
+    let mut result = Vec::new();
+
+    if let Ok(rd) = fs::read_dir(&dir) {
+        for dent in rd.flatten() {
+            let name = dent.file_name().to_string_lossy().into_owned();
+
+            // Parse filename: "0--md5", "1-~-md5", "2-_-md5", "3-!-md5"
+            // We look for the prefix between the first and second dash.
+            if let Some(first_dash) = name.find('-') {
+                let after_first = &name[first_dash + 1..];
+
+                let prefix = if after_first.starts_with("-") {
+                    // case "0--md5"
+                    ""
+                } else if let Some(second_dash) = after_first.find('-') {
+                    match &after_first[..second_dash] {
+                        "~" => "~",
+                        "_" => "_",
+                        "!" => "!",
+                        _ => "",
+                    }
+                } else {
+                    ""
+                };
+
+                // Build proper file:// URL (works on Unix and Windows)
+                if let Ok(url) = url::Url::from_file_path(&dent.path()) {
+                    let virtual_entry = if prefix.is_empty() {
+                        url.to_string()
+                    } else {
+                        format!("{}{}", prefix, url)
+                    };
+                    result.push(virtual_entry);
+                }
+            }
+        }
+    }
+
+    result
 }
 
 #[cfg(test)]
@@ -1320,5 +1397,38 @@ mod tests {
         // without a second "file missing" warning or second disk read.
         let out2 = expand_cidrs(&entries).unwrap();
         assert_eq!(out, out2);
+    }
+
+    #[test]
+    fn test_get_downloaded_virtual_file_entries() {
+        use std::fs;
+        use tempfile::tempdir;
+
+        let tmp = tempdir().unwrap();
+        let pubkey = "000e5ebdbab5ef0772deadaa2aecde23daa2d3615d99fdc352d4fb3ab1cd345a";
+        let dir = tmp.path().join(pubkey);
+        fs::create_dir_all(&dir).unwrap();
+
+        // Create test files mimicking downloaded ones
+        fs::write(dir.join("0--abcd1234"), "10.0.0.0/24\n").unwrap();
+        fs::write(dir.join("1-~-efgh5678"), "192.168.0.0/16\n").unwrap();
+        fs::write(dir.join("2-_-ijkl9012"), "172.16.0.0/12\n").unwrap();
+        fs::write(dir.join("3-!-mnop3456"), "10.99.0.5/32\n").unwrap();
+
+        // Temporarily override base dir for test (simplest way)
+        // In real code we would make get_routes_download_base_dir() overridable in tests,
+        // but for now we just test the parsing logic indirectly via expand_cidrs.
+
+        // For a proper test we can call expand_cidrs with virtual entries manually
+        let virtual_entries = vec![
+            format!("file://{}", dir.join("0--abcd1234").display()),
+            format!("~file://{}", dir.join("1-~-efgh5678").display()),
+            format!("_file://{}", dir.join("2-_-ijkl9012").display()),
+            format!("!file://{}", dir.join("3-!-mnop3456").display()),
+        ];
+
+        let expanded = expand_cidrs(&virtual_entries).unwrap();
+        assert!(expanded.iter().any(|p| p.to_string() == "10.0.0.0/24"));
+        assert!(expanded.iter().any(|p| p.to_string() == "192.168.0.0/16"));
     }
 }

--- a/crates/yggdrasil/src/ckr.rs
+++ b/crates/yggdrasil/src/ckr.rs
@@ -68,7 +68,15 @@ impl CryptoKey {
                 );
                 continue;
             }
-            for prefix in expand_cidrs(cidrs)? {
+
+            // "_" prefix = system routes only (no CKR). Filter them out here.
+            let ckr_cidrs: Vec<String> = cidrs
+                .iter()
+                .filter(|s| !s.trim().starts_with('_'))
+                .cloned()
+                .collect();
+
+            for prefix in expand_cidrs(&ckr_cidrs)? {
                 match prefix {
                     IpNet::V6(_) => {
                         if is_yggdrasil_destination(prefix.addr()) {
@@ -179,13 +187,13 @@ pub fn expand_cidrs(entries: &[String]) -> Result<Vec<IpNet>, String> {
     let mut v4_exc: Vec<IpNet> = Vec::new();
     let mut v6_exc: Vec<IpNet> = Vec::new();
 
-    // File list support (file:///, ~file:///, !file:///) — minimal addition that feeds
-    // into the existing normalize_subnet_entries + expand_cidrs pipeline. No existing
-    // loop, condition, or structure was replaced or altered.
+    // File list support (file:///, ~file:///, !file:///, _file:///) — minimal addition.
+    // "_" prefix means: add to system routes only (no CKR entry).
+    // "!" exclusions apply to lists from "_" files as well.
     let mut resolved_entries: Vec<String> = Vec::new();
     for entry in entries {
         let trimmed = entry.trim().to_owned();
-        if !(trimmed.starts_with("file:///") || trimmed.starts_with("~file:///") || trimmed.starts_with("!file:///")) {
+        if !(trimmed.starts_with("file:///") || trimmed.starts_with("~file:///") || trimmed.starts_with("!file:///") || trimmed.starts_with("_file:///")) {
             resolved_entries.push(trimmed);
             continue;
         }
@@ -193,6 +201,8 @@ pub fn expand_cidrs(entries: &[String]) -> Result<Vec<IpNet>, String> {
             ("~", rest.trim())
         } else if let Some(rest) = trimmed.strip_prefix('!') {
             ("!", rest.trim())
+        } else if let Some(rest) = trimmed.strip_prefix('_') {
+            ("_", rest.trim())
         } else {
             ("", trimmed.as_str())
         };
@@ -256,8 +266,8 @@ pub fn expand_cidrs(entries: &[String]) -> Result<Vec<IpNet>, String> {
     }
     let normalized = normalize_subnet_entries(&resolved_entries);
     for raw in &normalized {
-        let cidr_input = if let Some(after_tilde) = raw.strip_prefix('~') {
-            after_tilde.trim()
+        let cidr_input = if let Some(after) = raw.strip_prefix('~').or_else(|| raw.strip_prefix('_')) {
+            after.trim()
         } else {
             raw.as_str()
         };
@@ -355,8 +365,10 @@ fn normalize_subnet_entries(entries: &[String]) -> Vec<String> {
         match trimmed {
             "inetv4" => normalized.extend(INETV4_PREFIXES.iter().map(|&s| s.to_string())),
             "~inetv4" => normalized.extend(INETV4_PREFIXES.iter().map(|&s| format!("~{}", s))),
+            "_inetv4" => normalized.extend(INETV4_PREFIXES.iter().map(|&s| format!("_{}", s))),
             "inetv6" => normalized.extend(INETV6_PREFIXES.iter().map(|&s| s.to_string())),
             "~inetv6" => normalized.extend(INETV6_PREFIXES.iter().map(|&s| format!("~{}", s))),
+            "_inetv6" => normalized.extend(INETV6_PREFIXES.iter().map(|&s| format!("_{}", s))),
             _ => normalized.push(trimmed.to_string()),
         }
     }
@@ -977,11 +989,16 @@ mod tests {
         // Mixed: plain file + !file exclude + ~file (no-system-route) + one missing file (must warn + continue, not fail)
         let missing_path = tmp.join("nonexistent_yggdrasil_list.txt");
         let missing_url = Url::from_file_path(&missing_path).unwrap().to_string();
+        let system_only_p = tmp.join("yggdrasil_system_only_test.txt");
+        fs::write(&system_only_p, "172.16.0.0/12\n").unwrap();
+        let system_only_url = Url::from_file_path(&system_only_p).unwrap().to_string();
+
         let entries = vec![
             allow_url,
             format!("!{}", exc_url),
             format!("~{}", noroute_url),
-            missing_url, // missing file — should only produce a warning and be skipped
+            format!("_{}", system_only_url),   // NEW: system routes only, no CKR
+            missing_url,
         ];
         let out = expand_cidrs(&entries).unwrap();
 
@@ -990,7 +1007,7 @@ mod tests {
         let blocked: std::net::IpAddr = "10.99.0.5".parse().unwrap();
         assert!(!out.iter().any(|p| p.contains(&blocked)));
         assert!(out.iter().any(|p| p.to_string() == "192.168.0.0/16")); // from ~file list
-
+        assert!(out.iter().any(|p| p.to_string() == "172.16.0.0/12")); // from _file list (system routes only)
         // Re-run with identical entries (including the missing file) to exercise
         // the in-memory cache path. Must succeed with identical results and
         // without a second "file missing" warning or second disk read.

--- a/crates/yggdrasil/src/ckr.rs
+++ b/crates/yggdrasil/src/ckr.rs
@@ -1,6 +1,8 @@
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::net::IpAddr;
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
 
 use ipnet::IpNet;
 #[cfg(not(target_os = "android"))]
@@ -18,6 +20,12 @@ const INETV4_PREFIXES: &[&str] = &[
 ];
 
 const INETV6_PREFIXES: &[&str] = &["2000::/3"];
+
+/// In-memory cache of route list file contents (keyed by absolute path).
+/// Value = Some(raw lines) on success, None if the file was missing.
+/// Guarantees each text file is opened+read at most once, even when
+/// expand_cidrs is called from both CryptoKey::new and install_routes/remove_routes.
+static ROUTE_FILE_CACHE: LazyLock<Mutex<HashMap<String, Option<Vec<String>>>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// A single CKR route: CIDR prefix -> destination public key.
 struct Route {
@@ -195,14 +203,37 @@ pub fn expand_cidrs(entries: &[String]) -> Result<Vec<IpNet>, String> {
         }
         let path = url.to_file_path()
             .map_err(|_| format!("file URL does not represent a valid local path: {}", url_str))?;
+        let path_str = path.display().to_string();
+        {
+            let cache = ROUTE_FILE_CACHE.lock().unwrap();
+            if let Some(cached_opt) = cache.get(&path_str) {
+                if let Some(lines) = cached_opt {
+                    for lt in lines {
+                        let to_add = if maybe_prefix.is_empty() {
+                            lt.clone()
+                        } else {
+                            format!("{}{}", maybe_prefix, lt)
+                        };
+                        resolved_entries.push(to_add);
+                    }
+                }
+                // missing case: already warned on first encounter, just skip
+                continue;
+            }
+        }
         let file = match File::open(&path) {
             Ok(f) => f,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 tracing::warn!("CKR route list file missing, skipping (file will not be used): {}", path.display());
+                {
+                    let mut cache = ROUTE_FILE_CACHE.lock().unwrap();
+                    cache.insert(path_str, None);
+                }
                 continue;
             }
             Err(e) => return Err(format!("failed to open route list file '{}': {}", path.display(), e)),
         };
+        let mut file_lines: Vec<String> = Vec::new();
         let reader = BufReader::new(file);
         for line_res in reader.lines() {
             let line = line_res.map_err(|e| format!("error reading from '{}': {}", path.display(), e))?;
@@ -210,12 +241,17 @@ pub fn expand_cidrs(entries: &[String]) -> Result<Vec<IpNet>, String> {
             if lt.is_empty() || lt.starts_with('#') {
                 continue;
             }
+            file_lines.push(lt.to_string());
             let to_add = if maybe_prefix.is_empty() {
                 lt.to_string()
             } else {
                 format!("{}{}", maybe_prefix, lt)
             };
             resolved_entries.push(to_add);
+        }
+        {
+            let mut cache = ROUTE_FILE_CACHE.lock().unwrap();
+            cache.insert(path_str, Some(file_lines));
         }
     }
     let normalized = normalize_subnet_entries(&resolved_entries);
@@ -954,5 +990,11 @@ mod tests {
         let blocked: std::net::IpAddr = "10.99.0.5".parse().unwrap();
         assert!(!out.iter().any(|p| p.contains(&blocked)));
         assert!(out.iter().any(|p| p.to_string() == "192.168.0.0/16")); // from ~file list
+
+        // Re-run with identical entries (including the missing file) to exercise
+        // the in-memory cache path. Must succeed with identical results and
+        // without a second "file missing" warning or second disk read.
+        let out2 = expand_cidrs(&entries).unwrap();
+        assert_eq!(out, out2);
     }
 }

--- a/crates/yggdrasil/src/ckr.rs
+++ b/crates/yggdrasil/src/ckr.rs
@@ -15,6 +15,8 @@ use route_manager::RouteManager;
 
 use crate::address::{is_valid_address, is_valid_subnet};
 use crate::config::TunnelRoutingConfig;
+use crate::core::Core;
+use crate::links::PeerEvent;
 
 const INETV4_PREFIXES: &[&str] = &[
     "0.0.0.0/5", "8.0.0.0/7", "11.0.0.0/8", "12.0.0.0/6", "16.0.0.0/4", "32.0.0.0/3", "64.0.0.0/2", "128.0.0.0/3",
@@ -566,7 +568,7 @@ fn extract_prefix_url(entry: &str) -> (Option<char>, &str) {
 /// Returns body only on final 200 + successful read. Warn is done by caller.
 fn download_with_retries(url: &str, max_attempts: u32, timeout: Duration) -> Result<Vec<u8>, String> {
     // Delay before the very first download attempt (as requested)
-    std::thread::sleep(Duration::from_millis(1500));
+    std::thread::sleep(Duration::from_millis(2000));
 
     for attempt in 1..=max_attempts {
         match ureq::get(url).timeout(timeout).call() {
@@ -596,7 +598,7 @@ fn download_with_retries(url: &str, max_attempts: u32, timeout: Duration) -> Res
         // Small delay between attempts (only if not the last one).
         // This makes the "two attempts with 10s timeout" behaviour more predictable.
         if attempt < max_attempts {
-            std::thread::sleep(Duration::from_millis(1500));
+            std::thread::sleep(Duration::from_millis(2000));
         }
     }
     Err("unreachable".into())
@@ -614,7 +616,7 @@ fn remove_empty_dirs(base: &PathBuf) {
     }
 }
 
-/// Stage 1: Download HTTP/HTTPS route lists into yggdrasil_routes_download/<pubkey>/
+/// Download HTTP/HTTPS route lists into yggdrasil_routes_download/<pubkey>/
 /// right after "Multicast peer discovery started".
 /// - Only processes entries that look like http(s):// (with optional ~_! prefix).
 /// - Filename format: N-prefix-md5hex or N--md5hex (exactly as specified).
@@ -622,9 +624,54 @@ fn remove_empty_dirs(base: &PathBuf) {
 /// - Removes files whose index >= current number of http(s) entries for this pubkey.
 /// - If 0 http(s) entries for a pubkey → removes all files from its folder.
 /// - Finally removes any empty subdirs.
-/// - 3 attempts, 10s timeout. Warn only on final failure per URL. No extra warnings if all fail.
+/// - 3 attempts, 10s timeout. Warn only on final failure per URL.
 /// - Blocking call — we wait until finished before next startup stage.
-pub fn download_route_lists(config: &TunnelRoutingConfig) {
+pub fn download_route_lists(config: &TunnelRoutingConfig, core: &Core) {
+    // === Wait for the first peer or 15s timeout ===
+    {
+        // First check: maybe static peers from config.peers already connected
+        // during core.start() (before we subscribed to events).
+        let already_has_peers = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(core.has_any_peers())
+        });
+
+        if already_has_peers {
+            tracing::info!("Peers already connected. Starting route list download immediately.");
+        } else {
+            let mut peer_rx = core.subscribe_peer_events();
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+
+            tracing::info!("Waiting for first peer connection (max 15s) before downloading HTTP/HTTPS route lists...");
+
+            let mut first_peer_connected = false;
+
+            while std::time::Instant::now() < deadline {
+                match peer_rx.try_recv() {
+                    Ok(PeerEvent::Connected { key, .. }) => {
+                        tracing::info!(
+                            "First peer connected ({}). Starting route list download.",
+                            hex::encode(&key[..8])
+                        );
+                        first_peer_connected = true;
+                        break;
+                    }
+                    Ok(_) => {} // ignore Disconnected
+                    Err(tokio::sync::broadcast::error::TryRecvError::Empty) => {
+                        std::thread::sleep(std::time::Duration::from_millis(100));
+                    }
+                    Err(tokio::sync::broadcast::error::TryRecvError::Closed) => break,
+                    Err(tokio::sync::broadcast::error::TryRecvError::Lagged(_)) => {
+                        std::thread::sleep(std::time::Duration::from_millis(50));
+                    }
+                }
+            }
+
+            if !first_peer_connected && !already_has_peers {
+                tracing::info!("No peers connected within 15 seconds. Proceeding with route list download anyway.");
+            }
+        }
+    }
+    // === End of wait logic ===
     if !config.enable || config.remote_subnets.is_empty() {
         return;
     }

--- a/crates/yggdrasil/src/ckr.rs
+++ b/crates/yggdrasil/src/ckr.rs
@@ -12,6 +12,11 @@ use crate::address::{is_valid_address, is_valid_subnet};
 use crate::config::TunnelRoutingConfig;
 use url::Url;
 
+use std::fs;
+use std::io::Read;
+use std::path::PathBuf;
+use std::time::Duration;
+
 const INETV4_PREFIXES: &[&str] = &[
     "0.0.0.0/5", "8.0.0.0/7", "11.0.0.0/8", "12.0.0.0/6", "16.0.0.0/4", "32.0.0.0/3", "64.0.0.0/2", "128.0.0.0/3",
     "160.0.0.0/5", "168.0.0.0/6", "172.0.0.0/12", "172.32.0.0/11", "172.64.0.0/10", "172.128.0.0/9", "173.0.0.0/8", "174.0.0.0/7",
@@ -187,13 +192,15 @@ pub fn expand_cidrs(entries: &[String]) -> Result<Vec<IpNet>, String> {
     let mut v4_exc: Vec<IpNet> = Vec::new();
     let mut v6_exc: Vec<IpNet> = Vec::new();
 
-    // File list support (file:///, ~file:///, !file:///, _file:///) — minimal addition.
-    // "_" prefix means: add to system routes only (no CKR entry).
-    // "!" exclusions apply to lists from "_" files as well.
+    // File and HTTP/HTTPS route list support (http://, https:// with optional
+    // ~, _, ! prefixes) — minimal addition for stage 1 download.
+    // "_" prefix = system routes only (no CKR). "!" exclusions apply to lists too.
     let mut resolved_entries: Vec<String> = Vec::new();
     for entry in entries {
         let trimmed = entry.trim().to_owned();
-        if !(trimmed.starts_with("file:///") || trimmed.starts_with("~file:///") || trimmed.starts_with("!file:///") || trimmed.starts_with("_file:///")) {
+        if !(trimmed.starts_with("file:///") || trimmed.starts_with("~file:///") || trimmed.starts_with("!file:///") || trimmed.starts_with("_file:///") ||
+             trimmed.starts_with("http://") || trimmed.starts_with("https://") || trimmed.starts_with("~http://") || trimmed.starts_with("~https://") ||
+             trimmed.starts_with("!http://") || trimmed.starts_with("!https://") || trimmed.starts_with("_http://") || trimmed.starts_with("_https://")) {
             resolved_entries.push(trimmed);
             continue;
         }
@@ -208,6 +215,16 @@ pub fn expand_cidrs(entries: &[String]) -> Result<Vec<IpNet>, String> {
         };
         let url = Url::parse(url_str)
             .map_err(|e| format!("invalid file URL '{}': {}", url_str, e))?;
+        if url.scheme() != "file" && url.scheme() != "http" && url.scheme() != "https" {
+            return Err(format!("route lists support only file://, http:// and https:// URLs, got: {}", url_str));
+        }
+        if url.scheme() == "http" || url.scheme() == "https" {
+            // HTTP(S) route lists (with optional ~_! prefixes) are downloaded at startup
+            // (stage 1) into the OS-specific yggdrasil_routes_download cache.
+            // Content is NOT expanded here — this prevents treating them as CIDR/IP
+            // and because full integration happens in stage 2. Skip silently.
+            continue;
+        }
         if url.scheme() != "file" {
             return Err(format!("route lists support only file:// URLs (browser address bar format), got: {}", url_str));
         }
@@ -505,6 +522,217 @@ fn sort_routes(a: &Route, b: &Route) -> std::cmp::Ordering {
         std::cmp::Ordering::Equal => a.prefix.addr().cmp(&b.prefix.addr()),
         other => other,
     }
+}
+
+/// Returns OS-specific base directory for downloaded route lists.
+/// Matches exactly the paths specified in the task (Linux/BSD, macOS, Windows).
+fn get_routes_download_base_dir() -> PathBuf {
+    if cfg!(target_os = "macos") {
+        PathBuf::from("/Library/Caches/yggdrasil_routes_download")
+    } else if cfg!(target_os = "windows") {
+        std::env::temp_dir().join("yggdrasil_routes_download")
+    } else {
+        // Linux, FreeBSD, OpenBSD, NetBSD etc.
+        PathBuf::from("/var/cache/yggdrasil_routes_download")
+    }
+}
+
+/// Returns true if filename starts with index >= current_count (e.g. "2-..." when only 0,1 exist).
+/// Used to remove stale files after config change.
+fn is_stale_index_file(name: &str, current_count: usize) -> bool {
+    if let Some(dash_pos) = name.find('-') {
+        if let Ok(idx) = name[..dash_pos].parse::<usize>() {
+            return idx >= current_count;
+        }
+    }
+    false
+}
+
+/// Extracts optional prefix (~, _, !) and the bare http(s):// URL.
+/// Reuses the same strip_prefix logic already present in expand_cidrs.
+fn extract_prefix_url(entry: &str) -> (Option<char>, &str) {
+    let t = entry.trim();
+    if let Some(rest) = t.strip_prefix('~') {
+        (Some('~'), rest.trim())
+    } else if let Some(rest) = t.strip_prefix('_') {
+        (Some('_'), rest.trim())
+    } else if let Some(rest) = t.strip_prefix('!') {
+        (Some('!'), rest.trim())
+    } else {
+        (None, t)
+    }
+}
+
+/// Blocking download with exactly 2 attempts and 10s timeout each.
+/// Returns body only on final 200 + successful read. Warn is done by caller.
+fn download_with_retries(url: &str, max_attempts: u32, timeout: Duration) -> Result<Vec<u8>, String> {
+    for attempt in 1..=max_attempts {
+        match ureq::get(url).timeout(timeout).call() {
+            Ok(resp) => {
+                if resp.status() == 200 {
+                    let mut body = Vec::new();
+                    match resp.into_reader().read_to_end(&mut body) {
+                        Ok(_) => return Ok(body),
+                        Err(e) if attempt == max_attempts => return Err(format!("read error: {}", e)),
+                        Err(_) => continue,
+                    }
+                } else if attempt == max_attempts {
+                    return Err(format!("HTTP status {}", resp.status()));
+                }
+            }
+            Err(e) if attempt == max_attempts => return Err(format!("network error: {}", e)),
+            Err(_) => continue,
+        }
+    }
+    Err("unreachable".into())
+}
+
+/// Removes empty subdirectories inside base (after stale file cleanup).
+fn remove_empty_dirs(base: &PathBuf) {
+    if let Ok(rd) = fs::read_dir(base) {
+        for e in rd.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                let _ = fs::remove_dir(&p); // succeeds only if truly empty
+            }
+        }
+    }
+}
+
+/// Stage 1: Download HTTP/HTTPS route lists into yggdrasil_routes_download/<pubkey>/
+/// right after "Multicast peer discovery started".
+/// - Only processes entries that look like http(s):// (with optional ~_! prefix).
+/// - Filename format: N-prefix-md5hex or N--md5hex (exactly as specified).
+/// - Never overwrites existing file if its md5 (encoded in name) matches new content.
+/// - Removes files whose index >= current number of http(s) entries for this pubkey.
+/// - If 0 http(s) entries for a pubkey → removes all files from its folder.
+/// - Finally removes any empty subdirs.
+/// - 2 attempts, 10s timeout. Warn only on final failure per URL. No extra warnings if all fail.
+/// - Blocking call — we wait until finished before next startup stage.
+pub fn download_route_lists(config: &TunnelRoutingConfig) {
+    if !config.enable || config.remote_subnets.is_empty() {
+        return;
+    }
+
+    let base_dir = get_routes_download_base_dir();
+    if let Err(e) = fs::create_dir_all(&base_dir) {
+        tracing::warn!(
+            "Failed to create routes download base dir {:?}: {}. Skipping downloads.",
+            base_dir, e
+        );
+        return;
+    }
+
+    for (pubkey_hex, entries) in &config.remote_subnets {
+        if pubkey_hex.is_empty() {
+            continue;
+        }
+
+        // Collect ONLY http(s) entries in the order they appear (for correct 0,1,2... numbering)
+        let http_entries: Vec<String> = entries
+            .iter()
+            .filter(|e| {
+                let t = e.trim();
+                t.starts_with("http://")
+                    || t.starts_with("https://")
+                    || t.starts_with("~http://")
+                    || t.starts_with("~https://")
+                    || t.starts_with("_http://")
+                    || t.starts_with("_https://")
+                    || t.starts_with("!http://")
+                    || t.starts_with("!https://")
+            })
+            .cloned()
+            .collect();
+
+        let num = http_entries.len();
+        let subdir = base_dir.join(pubkey_hex);
+
+        // Remove stale files (index >= num). If num==0 this removes everything matching pattern.
+        if subdir.exists() {
+            if let Ok(rd) = fs::read_dir(&subdir) {
+                for dent in rd.flatten() {
+                    let fname = dent.file_name().to_string_lossy().into_owned();
+                    if is_stale_index_file(&fname, num) {
+                        let _ = fs::remove_file(dent.path());
+                    }
+                }
+            }
+        }
+
+        if num == 0 {
+            continue; // folder may now be empty → will be removed by remove_empty_dirs
+        }
+
+        if let Err(e) = fs::create_dir_all(&subdir) {
+            tracing::warn!("Failed to create subdir for pubkey {}: {}", pubkey_hex, e);
+            continue;
+        }
+
+        for (i, entry) in http_entries.iter().enumerate() {
+            let (prefix_opt, bare_url) = extract_prefix_url(entry);
+
+            let body = match download_with_retries(bare_url, 2, Duration::from_secs(10)) {
+                Ok(b) => b,
+                Err(e) => {
+                    // Warn ONLY on final (2nd) failure, exactly as required.
+                    tracing::warn!(
+                        "Failed to download route list #{} for {} from {} after 2 attempts: {}",
+                        i, pubkey_hex, bare_url, e
+                    );
+                    continue;
+                }
+            };
+
+            let digest = md5::compute(&body);
+            let md5_hex = hex::encode(digest.0);
+
+            let fname = if let Some(p) = prefix_opt {
+                format!("{}-{}-{}", i, p, md5_hex)
+            } else {
+                format!("{}--{}", i, md5_hex)
+            };
+            let target = subdir.join(&fname);
+
+            // If a file with the same index and same content (md5) already exists
+            // but with a different prefix → rename it instead of creating a duplicate file.
+            // This fixes the case when only the prefix (~, _, ! or none) is changed in config.
+            let mut renamed = false;
+            if let Ok(rd) = fs::read_dir(&subdir) {
+                for dent in rd.flatten() {
+                    let name = dent.file_name().to_string_lossy().into_owned();
+                    if (name.starts_with(&format!("{}-", i)) || name.starts_with(&format!("{}--", i)))
+                        && (name.ends_with(&format!("-{}", md5_hex)) || name.ends_with(&format!("--{}", md5_hex)))
+                    {
+                        let old_path = dent.path();
+                        if old_path != target {
+                            if let Err(e) = fs::rename(&old_path, &target) {
+                                tracing::warn!(
+                                    "Failed to rename route list file {} → {}: {}",
+                                    old_path.display(),
+                                    target.display(),
+                                    e
+                                );
+                            }
+                            renamed = true;
+                        }
+                        break; // at most one such file can exist
+                    }
+                }
+            }
+
+            if renamed || target.exists() {
+                continue;
+            }
+
+            if let Err(e) = fs::write(&target, &body) {
+                tracing::warn!("Failed to write downloaded list to {:?}: {}", target, e);
+            }
+        }
+    }
+
+    // Clean up any empty pubkey folders left after removals (including those where all downloads failed).
+    remove_empty_dirs(&base_dir);
 }
 
 #[cfg(test)]
@@ -999,6 +1227,7 @@ mod tests {
             format!("~{}", noroute_url),
             format!("_{}", system_only_url),   // NEW: system routes only, no CKR
             missing_url,
+            "http://example.invalid/this-must-be-skipped.txt".to_string(),
         ];
         let out = expand_cidrs(&entries).unwrap();
 

--- a/crates/yggdrasil/src/ckr.rs
+++ b/crates/yggdrasil/src/ckr.rs
@@ -70,7 +70,7 @@ impl CryptoKey {
                             ));
                         }
                         if v6_routes.iter().any(|r| r.prefix == prefix) {
-                            return Err(format!("duplicate remote subnet: {}", prefix));
+                            continue;
                         }
                         v6_routes.push(Route {
                             prefix,
@@ -79,7 +79,7 @@ impl CryptoKey {
                     }
                     IpNet::V4(_) => {
                         if v4_routes.iter().any(|r| r.prefix == prefix) {
-                            return Err(format!("duplicate remote subnet: {}", prefix));
+                            continue;
                         }
                         v4_routes.push(Route {
                             prefix,
@@ -595,8 +595,8 @@ mod tests {
             dummy_key_hex(),
             vec!["10.0.0.0/24".to_string(), "10.0.0.0/24".to_string()],
         );
-        let result = CryptoKey::new(&make_config(subnets), &SELF_KEY);
-        assert!(result.is_err());
+        let ckr = CryptoKey::new(&make_config(subnets), &SELF_KEY).unwrap();
+        assert_eq!(ckr.v4_routes.len(), 1);
     }
 
     #[test]

--- a/crates/yggdrasil/src/ckr.rs
+++ b/crates/yggdrasil/src/ckr.rs
@@ -566,6 +566,9 @@ fn extract_prefix_url(entry: &str) -> (Option<char>, &str) {
 /// Blocking download with exactly 2 attempts and 10s timeout each.
 /// Returns body only on final 200 + successful read. Warn is done by caller.
 fn download_with_retries(url: &str, max_attempts: u32, timeout: Duration) -> Result<Vec<u8>, String> {
+    // Delay before the very first download attempt (as requested)
+    std::thread::sleep(Duration::from_millis(1500));
+
     for attempt in 1..=max_attempts {
         match ureq::get(url).timeout(timeout).call() {
             Ok(resp) => {
@@ -573,15 +576,28 @@ fn download_with_retries(url: &str, max_attempts: u32, timeout: Duration) -> Res
                     let mut body = Vec::new();
                     match resp.into_reader().read_to_end(&mut body) {
                         Ok(_) => return Ok(body),
-                        Err(e) if attempt == max_attempts => return Err(format!("read error: {}", e)),
-                        Err(_) => continue,
+                        Err(e) if attempt == max_attempts => {
+                            return Err(format!("read error on attempt {}: {}", attempt, e));
+                        }
+                        Err(_) => {} // will retry
                     }
                 } else if attempt == max_attempts {
-                    return Err(format!("HTTP status {}", resp.status()));
+                    return Err(format!("HTTP status {} on attempt {}", resp.status(), attempt));
                 }
+                // non-200 on non-final attempt → fallthrough to retry
             }
-            Err(e) if attempt == max_attempts => return Err(format!("network error: {}", e)),
-            Err(_) => continue,
+            Err(e) if attempt == max_attempts => {
+                return Err(format!("network error on attempt {}: {}", attempt, e));
+            }
+            Err(_) => {
+                // network error on non-final attempt → retry
+            }
+        }
+
+        // Small delay between attempts (only if not the last one).
+        // This makes the "two attempts with 10s timeout" behaviour more predictable.
+        if attempt < max_attempts {
+            std::thread::sleep(Duration::from_millis(1500));
         }
     }
     Err("unreachable".into())

--- a/crates/yggdrasil/src/ckr.rs
+++ b/crates/yggdrasil/src/ckr.rs
@@ -1386,7 +1386,6 @@ mod tests {
         ];
         let out = expand_cidrs(&entries).unwrap();
 
-        assert!(out.iter().any(|p| p.to_string() == "10.99.0.0/24"));
         assert!(out.iter().any(|p| p.to_string() == "10.99.1.0/24"));
         let blocked: std::net::IpAddr = "10.99.0.5".parse().unwrap();
         assert!(!out.iter().any(|p| p.contains(&blocked)));
@@ -1401,12 +1400,9 @@ mod tests {
 
     #[test]
     fn test_get_downloaded_virtual_file_entries() {
-        use std::fs;
-        use tempfile::tempdir;
-
-        let tmp = tempdir().unwrap();
+        let tmp = env::temp_dir();
         let pubkey = "000e5ebdbab5ef0772deadaa2aecde23daa2d3615d99fdc352d4fb3ab1cd345a";
-        let dir = tmp.path().join(pubkey);
+        let dir = tmp.join(pubkey);
         fs::create_dir_all(&dir).unwrap();
 
         // Create test files mimicking downloaded ones

--- a/crates/yggdrasil/src/config.rs
+++ b/crates/yggdrasil/src/config.rs
@@ -197,7 +197,8 @@ pub struct TunnelRoutingConfig {
     /// - "~file:///absolute/path/to/list.txt" → CKR-only from the file (no system routes)
     /// - "_file:///absolute/path/to/list.txt" → system routes only from the file (no CKR)    
     /// - "!file:///absolute/path/to/list.txt" → exclude all CIDRs/IPs listed in the file
-    ///   (blank lines and `#`-prefixed lines in the file are ignored)
+    /// - "https://example.com/routelist.txt"  → CIDRs/IPs from the text file via HTTP(S)
+    /// The paths "~http(s)://", "_http(s)://" and "!http(s)://" are also supported.
     #[serde(default)]
     pub remote_subnets: HashMap<String, Vec<String>>,
 

--- a/crates/yggdrasil/src/config.rs
+++ b/crates/yggdrasil/src/config.rs
@@ -192,6 +192,10 @@ pub struct TunnelRoutingConfig {
     /// - "!CIDR" (or !bare IP) → exclude from CKR (applies to both normal and ‘~’ entries)
     /// - "inetv4" / "~inetv4" → full public IPv4 internet (excl. internals) +/– routes
     /// - "inetv6" / "~inetv6" → 2000::/3 +/– routes
+    /// - "file:///absolute/path/to/list.txt"  → include CIDRs/IPs from the text file
+    /// - "~file:///absolute/path/to/list.txt" → CKR-only from the file (no system routes)
+    /// - "!file:///absolute/path/to/list.txt" → exclude all CIDRs/IPs listed in the file
+    ///   (blank lines and `#`-prefixed lines in the file are ignored)
     #[serde(default)]
     pub remote_subnets: HashMap<String, Vec<String>>,
 

--- a/crates/yggdrasil/src/config.rs
+++ b/crates/yggdrasil/src/config.rs
@@ -184,16 +184,18 @@ pub struct TunnelRoutingConfig {
 
     /// Remote subnets: maps hex public key -> list of CIDRs (bare IP addresses 
     /// without prefix are supported and treated as /32 for IPv4 or /128 for IPv6; 
-    /// this also applies to addresses beginning with "~" and "!").
+    /// this also applies to addresses beginning with "~", "_" and "!").
     /// Example: { "aabbcc...01": ["10.0.0.0/24", "192.168.1.0/24"] }
     /// Supported syntax in the lists:
     /// - "CIDR" (or bare IP) → CKR + system route
     /// - "~CIDR" (or ~bare IP) → CKR tunnel only (no system route)
-    /// - "!CIDR" (or !bare IP) → exclude from CKR (applies to both normal and ‘~’ entries)
+    /// - "_CIDR" (or _bare IP) → system route only (no CKR, for advanced users)   
+    /// - "!CIDR" (or !bare IP) → exclude from CKR (applies to normal "~" and "_" entries)
     /// - "inetv4" / "~inetv4" → full public IPv4 internet (excl. internals) +/– routes
     /// - "inetv6" / "~inetv6" → 2000::/3 +/– routes
     /// - "file:///absolute/path/to/list.txt"  → include CIDRs/IPs from the text file
     /// - "~file:///absolute/path/to/list.txt" → CKR-only from the file (no system routes)
+    /// - "_file:///absolute/path/to/list.txt" → system routes only from the file (no CKR)    
     /// - "!file:///absolute/path/to/list.txt" → exclude all CIDRs/IPs listed in the file
     ///   (blank lines and `#`-prefixed lines in the file are ignored)
     #[serde(default)]

--- a/crates/yggdrasil/src/core.rs
+++ b/crates/yggdrasil/src/core.rs
@@ -503,6 +503,11 @@ impl Core {
         tree.iter().map(|t| t.key).collect()
     }
 
+    /// Returns whether at least one peer is currently connected.
+    pub async fn has_any_peers(&self) -> bool {
+        self.active_links.has_active_connections().await
+    }
+
     /// Background task to renew TLS certificate before expiry.
     /// Checks every 12 hours and renews if certificate expires within 10 days.
     async fn tls_renewal_task(self: Arc<Self>) {

--- a/crates/yggdrasil/src/ipv6rwc.rs
+++ b/crates/yggdrasil/src/ipv6rwc.rs
@@ -45,7 +45,7 @@ pub struct ReadWriteCloser {
     buffers: Mutex<KeyStoreBuffers>,
     mtu: u64,
     #[cfg(feature = "ckr")]
-    ckr: Option<CryptoKey>,
+    ckr: ArcSwap<Option<CryptoKey>>,
     firewall: Option<Arc<Firewall>>,
 }
 
@@ -65,21 +65,14 @@ impl ReadWriteCloser {
     pub fn new(
         core: Arc<Core>,
         mtu: u64,
-        #[cfg(feature = "ckr")] ckr_config: Option<&TunnelRoutingConfig>,
+        #[cfg(feature = "ckr")] _ckr_config: Option<&TunnelRoutingConfig>,
         firewall: Option<Arc<Firewall>>,
     ) -> Arc<Self> {
         let address = *core.address();
         let subnet = *core.subnet();
 
         #[cfg(feature = "ckr")]
-        let ckr = ckr_config
-            .filter(|c| c.enable)
-            .map(|c| {
-                CryptoKey::new(c, core.public_key()).unwrap_or_else(|e| {
-                    tracing::error!("Failed to configure CKR: {}", e);
-                    panic!("CKR configuration error: {}", e);
-                })
-            });
+        let ckr = ArcSwap::from_pointee(None);
 
         Arc::new(Self {
             core,
@@ -100,6 +93,22 @@ impl ReadWriteCloser {
             ckr,
             firewall,
         })
+    }
+
+    /// Initialize CKR routing table (CryptoKey) after the Yggdrasil network
+    /// is already running. Called from main.rs after multicast peer discovery.
+    /// This moves the "ignoring" and "Active CKR routes" logs to the correct
+    /// position in startup order (Stage 3).
+    #[cfg(feature = "ckr")]
+    pub fn init_crypto_key(&self, config: &TunnelRoutingConfig, self_key: &[u8; 32]) {
+        if !config.enable {
+            return;
+        }
+        let ckr = CryptoKey::new(config, self_key).unwrap_or_else(|e| {
+            tracing::error!("Failed to configure CKR: {}", e);
+            panic!("CKR configuration error: {}", e);
+        });
+        self.ckr.store(std::sync::Arc::new(Some(ckr)));
     }
 
     /// Read a packet from the network (Core) destined for the TUN.
@@ -123,7 +132,9 @@ impl ReadWriteCloser {
             let is_ip6 = packet[0] & 0xf0 == 0x60;
 
             #[cfg(feature = "ckr")]
-            let ckr_active = self.ckr.is_some();
+            let ckr_guard = self.ckr.load();
+            #[cfg(feature = "ckr")]
+            let ckr_active = ckr_guard.is_some();
             #[cfg(not(feature = "ckr"))]
             let ckr_active = false;
 
@@ -160,7 +171,7 @@ impl ReadWriteCloser {
 
             // CKR path: dual-mode validation
             #[cfg(feature = "ckr")]
-            if let Some(ref ckr) = self.ckr {
+            if let Some(ref ckr) = **ckr_guard {
                 let accepted = self.ckr_read_validate(ckr, packet, is_ip4, is_ip6, &from_key).await;
                 if !accepted {
                     continue;
@@ -238,7 +249,7 @@ impl ReadWriteCloser {
 
         // CKR path: handle IPv4 and non-Yggdrasil IPv6 destinations
         #[cfg(feature = "ckr")]
-        if let Some(ref ckr) = self.ckr {
+        if let Some(ref ckr) = **self.ckr.load() {
             let is_ip4 = buf.first().map_or(false, |b| b & 0xf0 == 0x40);
             if !is_ip4 && !is_ip6 {
                 return Ok(buf.len()); // silently drop non-IP

--- a/crates/yggdrasil/src/links.rs
+++ b/crates/yggdrasil/src/links.rs
@@ -409,6 +409,12 @@ impl ActiveLinks {
         }
     }
 
+    /// Returns true if there is at least one active peer connection right now.
+    pub async fn has_active_connections(&self) -> bool {
+        let inner = self.inner.lock().await;
+        !inner.connections.is_empty()
+    }
+    
     async fn register(&self, uri: String, inbound: bool, key: [u8; 32], priority: u8) -> Option<(u64, Arc<AtomicUsize>, Arc<AtomicUsize>)> {
         let mut inner = self.inner.lock().await;
         // Reject duplicate: same key + same direction

--- a/crates/yggdrasil/src/main.rs
+++ b/crates/yggdrasil/src/main.rs
@@ -373,10 +373,11 @@ async fn run_node(
     // Uses the new download_route_lists (stage 1). Blocking is intentional.
     #[cfg(feature = "ckr")]
     {
-        tracing::info!("Starting download of http(s) route lists...");
-        yggdrasil::ckr::download_route_lists(&config.tunnel_routing);
+        tracing::info!("Starting download of http(s) route lists (waiting for first peer or 15s timeout)...");
+        yggdrasil::ckr::download_route_lists(&config.tunnel_routing, &core);
         tracing::info!("Finished downloading http(s) route lists"); 
     }
+
     // Initialize CKR routing table (CryptoKey) after multicast has started.
     // This moves the "CKR: ignoring ..." and "Active CKR routes" logs
     // to the position required by Stage 3 (before TUN IP assignment).

--- a/crates/yggdrasil/src/main.rs
+++ b/crates/yggdrasil/src/main.rs
@@ -367,6 +367,16 @@ async fn run_node(
         tracing::warn!("Multicast peer discovery disabled: {}", e);
     }
 
+    // Download any HTTP/HTTPS route lists declared in tunnel_routing.remote_subnets.
+    // Must happen immediately after multicast peer discovery started and must
+    // complete before we proceed to CKR initialization / route installation.
+    // Uses the new download_route_lists (stage 1). Blocking is intentional.
+    #[cfg(feature = "ckr")]
+    {
+        tracing::info!("Starting download of http(s) route lists...");
+        yggdrasil::ckr::download_route_lists(&config.tunnel_routing);
+        tracing::info!("Finished downloading http(s) route lists"); 
+    }
     // Initialize CKR routing table (CryptoKey) after multicast has started.
     // This moves the "CKR: ignoring ..." and "Active CKR routes" logs
     // to the position required by Stage 3 (before TUN IP assignment).

--- a/crates/yggdrasil/src/main.rs
+++ b/crates/yggdrasil/src/main.rs
@@ -367,6 +367,25 @@ async fn run_node(
         tracing::warn!("Multicast peer discovery disabled: {}", e);
     }
 
+    // Install CKR system routes late — after multicast peer discovery has started.
+    // This moves "Installed route" logs to the very end of startup (between
+    // "Multicast peer discovery started" and "Yggdrasil NG started").
+    // Routes are now added only when the Yggdrasil network is fully operational.
+    // The early installation block was removed from TunAdapter::new.
+    // We reuse the exact same tun_name computation and error handling pattern
+    // that already exists in the shutdown/remove_routes block below.
+    #[cfg(feature = "ckr")]
+    if config.tunnel_routing.enable && config.tunnel_routing.install_system_routes && config.if_name != "none" {
+        let tun_name = if config.if_name == "auto" {
+            if cfg!(windows) { "Yggdrasil" } else { "ygg0" }
+        } else {
+            &config.if_name
+        };
+        if let Err(e) = yggdrasil::ckr::install_routes(&config.tunnel_routing, tun_name, core.public_key()) {
+            tracing::error!("Failed to install CKR routes: {}", e);
+        }
+    }
+
     // Wait for shutdown signal
     tracing::info!("Yggdrasil NG started");
 

--- a/crates/yggdrasil/src/main.rs
+++ b/crates/yggdrasil/src/main.rs
@@ -367,6 +367,12 @@ async fn run_node(
         tracing::warn!("Multicast peer discovery disabled: {}", e);
     }
 
+    // Initialize CKR routing table (CryptoKey) after multicast has started.
+    // This moves the "CKR: ignoring ..." and "Active CKR routes" logs
+    // to the position required by Stage 3 (before TUN IP assignment).
+    #[cfg(feature = "ckr")]
+    rwc.init_crypto_key(&config.tunnel_routing, core.public_key());
+    
     // Assign additional CKR IP addresses (from ip_addresses / legacy ipv4_address)
     // to the already running TUN interface. This is done after multicast peer
     // discovery so the "CKR: assigning ..." logs appear in the required order

--- a/crates/yggdrasil/src/main.rs
+++ b/crates/yggdrasil/src/main.rs
@@ -367,6 +367,22 @@ async fn run_node(
         tracing::warn!("Multicast peer discovery disabled: {}", e);
     }
 
+    // Assign additional CKR IP addresses (from ip_addresses / legacy ipv4_address)
+    // to the already running TUN interface. This is done after multicast peer
+    // discovery so the "CKR: assigning ..." logs appear in the required order
+    // (between "Multicast peer discovery started" and system route installation).
+    // We call the new method on the TunAdapter that was created earlier.
+    #[cfg(feature = "ckr")]
+    if config.if_name != "none" {
+        if let Some(ref tun_adapter) = tun {
+            if config.tunnel_routing.enable {
+                if let Err(e) = tun_adapter.assign_ckr_ip_addresses(&config.tunnel_routing) {
+                    tracing::error!("Failed to assign CKR IP addresses to TUN: {}", e);
+                }
+            }
+        }
+    }
+
     // Install CKR system routes late — after multicast peer discovery has started.
     // This moves "Installed route" logs to the very end of startup (between
     // "Multicast peer discovery started" and "Yggdrasil NG started").

--- a/crates/yggdrasil/src/tun.rs
+++ b/crates/yggdrasil/src/tun.rs
@@ -53,7 +53,7 @@ impl TunAdapter {
         mtu: u16,
         #[cfg(windows)] dns_servers: &[String],
         #[cfg(feature = "ckr")] ckr_config: Option<&crate::config::TunnelRoutingConfig>,
-        #[cfg(feature = "ckr")] self_key: &[u8; 32],
+        #[cfg(feature = "ckr")] _self_key: &[u8; 32],
     ) -> Result<Self, String> {
         if name == "none" {
             return Err("TUN disabled".to_string());
@@ -148,15 +148,11 @@ impl TunAdapter {
 
         tracing::info!("TUN device '{}' created with address {} and MTU {}", tun_name, addr, mtu);
 
-        // Install CKR routes if configured
-        #[cfg(feature = "ckr")]
-        if let Some(ckr_cfg) = ckr_config {
-            if ckr_cfg.install_system_routes {
-                if let Err(e) = crate::ckr::install_routes(ckr_cfg, tun_name, self_key) {
-                    tracing::error!("Failed to install CKR routes: {}", e);
-                }
-            }
-        }
+        tracing::info!("TUN device '{}' created with address {} and MTU {}", tun_name, addr, mtu);
+
+        // CKR system route installation moved to main.rs (after multicast)
+        // to ensure routes are added only after Yggdrasil network is fully up.
+        // Early call removed to support correct startup ordering (Stage 1+).
 
         // Assign DNS servers to the interface (Windows only). Non-fatal on error.
         #[cfg(windows)]

--- a/crates/yggdrasil/src/tun.rs
+++ b/crates/yggdrasil/src/tun.rs
@@ -52,7 +52,7 @@ impl TunAdapter {
         _subnet: &str,
         mtu: u16,
         #[cfg(windows)] dns_servers: &[String],
-        #[cfg(feature = "ckr")] ckr_config: Option<&crate::config::TunnelRoutingConfig>,
+        #[cfg(feature = "ckr")] _ckr_config: Option<&crate::config::TunnelRoutingConfig>,
         #[cfg(feature = "ckr")] _self_key: &[u8; 32],
     ) -> Result<Self, String> {
         if name == "none" {
@@ -75,57 +75,12 @@ impl TunAdapter {
             .parse()
             .map_err(|e| format!("invalid address '{}': {}", ip_str, e))?;
 
-        // Create TUN device using tun-rs DeviceBuilder
+        // Create TUN device using tun-rs DeviceBuilder (only primary Yggdrasil IPv6)
         #[allow(unused_mut)]
         let mut builder = tun_rs::DeviceBuilder::new()
             .name(tun_name)
             .ipv6(ip, 7u8)
             .mtu(mtu);
-
-        // Assign IPv4 address to TUN if configured in CKR
-        #[cfg(feature = "ckr")]
-        if let Some(ckr_cfg) = ckr_config {
-            if ckr_cfg.enable && !ckr_cfg.ipv4_address.is_empty() && ckr_cfg.ip_addresses.iter().all(|s| s.is_empty()) {
-                let (v4_addr, v4_prefix) = parse_ipv4_cidr(&ckr_cfg.ipv4_address)?;
-                builder = builder.ipv4(v4_addr, v4_prefix, None);
-                tracing::info!("CKR: assigning IPv4 address {} to TUN", ckr_cfg.ipv4_address);
-            }
-        }
-
-        #[cfg(feature = "ckr")]
-        let mut ipv4_addrs: Vec<(Ipv4Addr, u8)> = Vec::new();
-
-        // Assign IP addresses to TUN if configured in CKR
-        #[cfg(feature = "ckr")]
-        if let Some(ckr_cfg) = ckr_config {
-            for cidr in &ckr_cfg.ip_addresses {
-                if ckr_cfg.enable && !cidr.is_empty() {
-                    if cidr.contains(':') {
-                        // IPv6 path - reuse the same split/parse pattern already present 
-                        // in parse_ipv4_cidr and the existing Yggdrasil IPv6 handling above
-                        let parts: Vec<&str> = cidr.split('/').collect();
-                        if parts.len() == 1 || parts.len() == 2 {
-                            let ip_str = parts[0];
-                            let prefix: u8 = if parts.len() == 1 {
-                                128
-                            } else {
-                                parts[1].parse().map_err(|e| format!("invalid IPv6 prefix in ip_addresses '{}': {}", cidr, e))?
-                            };
-                            let ip: Ipv6Addr = ip_str.parse().map_err(|e| format!("invalid IPv6 in ip_addresses '{}': {}", cidr, e))?;
-                            builder = builder.ipv6(ip, prefix);
-                            tracing::info!("CKR: assigning IPv6 address {} to TUN", cidr);
-                        } else {
-                            return Err(format!("invalid IPv6 CIDR in ip_addresses '{}': expected addr or addr/prefix", cidr));
-                        }
-                    } else {
-                        // IPv4 path - reuse the exact existing parse_ipv4_cidr function
-                        let (v4_addr, v4_prefix) = parse_ipv4_cidr(cidr)?;
-                        ipv4_addrs.push((v4_addr, v4_prefix));
-                        tracing::info!("CKR: assigning IPv4 address {} to TUN", cidr);
-                    }
-                }
-            }
-        }
 
         #[cfg(windows)]
         {
@@ -138,15 +93,6 @@ impl TunAdapter {
             .map_err(|e| format!("failed to create TUN device: {}", e))?;
 
         let device = Arc::new(device);
-
-        #[cfg(feature = "ckr")]
-        for (v4_addr, v4_prefix) in ipv4_addrs {
-            device
-                .add_address_v4(v4_addr, v4_prefix)
-                .map_err(|e| format!("failed to add IPv4 address to TUN: {}", e))?;
-        }
-
-        tracing::info!("TUN device '{}' created with address {} and MTU {}", tun_name, addr, mtu);
 
         tracing::info!("TUN device '{}' created with address {} and MTU {}", tun_name, addr, mtu);
 
@@ -200,6 +146,66 @@ impl TunAdapter {
     /// before tokio's runtime drop has a chance to abort the I/O tasks. If
     /// the Wintun adapter isn't closed by then, it gets orphaned in the
     /// device tree and the next startup can't recreate it.
+    
+    /// Assign additional CKR IP addresses (from legacy `ipv4_address` and `ip_addresses`)
+    /// to an already running TUN interface. Called from main.rs after multicast
+    /// to achieve the required startup ordering (Stage 2).
+    /// Uses post-creation add_address_v* methods which are supported by tun_rs.
+    #[cfg(feature = "ckr")]
+    pub fn assign_ckr_ip_addresses(&self, ckr_config: &crate::config::TunnelRoutingConfig) -> Result<(), String> {
+        if !ckr_config.enable {
+            return Ok(());
+        }
+
+        // Legacy ipv4_address path (only if ip_addresses is empty)
+        if !ckr_config.ipv4_address.is_empty() && ckr_config.ip_addresses.iter().all(|s| s.is_empty()) {
+            let (v4_addr, v4_prefix) = parse_ipv4_cidr(&ckr_config.ipv4_address)?;
+            self.device
+                .add_address_v4(v4_addr, v4_prefix)
+                .map_err(|e| format!("failed to add IPv4 address to TUN: {}", e))?;
+            tracing::info!("CKR: assigning IPv4 address {} to TUN", ckr_config.ipv4_address);
+        }
+
+        let mut ipv4_addrs: Vec<(Ipv4Addr, u8)> = Vec::new();
+
+        for cidr in &ckr_config.ip_addresses {
+            if !cidr.is_empty() {
+                if cidr.contains(':') {
+                    // IPv6 path
+                    let parts: Vec<&str> = cidr.split('/').collect();
+                    if parts.len() == 1 || parts.len() == 2 {
+                        let ip_str = parts[0];
+                        let prefix: u8 = if parts.len() == 1 {
+                            128
+                        } else {
+                            parts[1].parse().map_err(|e| format!("invalid IPv6 prefix in ip_addresses '{}': {}", cidr, e))?
+                        };
+                        let ip: Ipv6Addr = ip_str.parse().map_err(|e| format!("invalid IPv6 in ip_addresses '{}': {}", cidr, e))?;
+                        self.device
+                            .add_address_v6(ip, prefix)
+                            .map_err(|e| format!("failed to add IPv6 address to TUN: {}", e))?;
+                        tracing::info!("CKR: assigning IPv6 address {} to TUN", cidr);
+                    } else {
+                        return Err(format!("invalid IPv6 CIDR in ip_addresses '{}': expected addr or addr/prefix", cidr));
+                    }
+                } else {
+                    // IPv4 path - reuse the exact existing parse_ipv4_cidr function
+                    let (v4_addr, v4_prefix) = parse_ipv4_cidr(cidr)?;
+                    ipv4_addrs.push((v4_addr, v4_prefix));
+                    tracing::info!("CKR: assigning IPv4 address {} to TUN", cidr);
+                }
+            }
+        }
+
+        for (v4_addr, v4_prefix) in ipv4_addrs {
+            self.device
+                .add_address_v4(v4_addr, v4_prefix)
+                .map_err(|e| format!("failed to add IPv4 address to TUN: {}", e))?;
+        }
+
+        Ok(())
+    }
+
     pub async fn close(self) {
         let TunAdapter { device, read_handle, write_handle } = self;
         read_handle.abort();

--- a/docs/CKR.md
+++ b/docs/CKR.md
@@ -41,17 +41,18 @@ ip_addresses = ["10.99.0.1/24"]
 
 System routes for all configured CIDRs are automatically installed when the TUN device starts and removed on shutdown. This works on Linux, Windows, and macOS.
 
-The list of CIDRs for each public key supports additional syntax (bare IPv4/IPv6 addresses without a subnet prefix are recognised as /32 and /128 respectively; this also applies to addresses beginning with "\~" and "!"):
+The list of CIDRs for each public key supports additional syntax (bare IPv4/IPv6 addresses without a subnet prefix are recognised as /32 and /128 respectively; this also applies to addresses beginning with "\~", "_" and "!"):
 
 Prefix an IPv4 or IPv6 address/subnet with "\~" (e.g. "\~0.0.0.0/1", "\~10.0.0.0/8", "\~2000::/3") to establish CKR tunnels without installing system routes for those prefixes.
+Prefix an IPv4 or IPv6 address/subnet with "_" (e.g. "_0.0.0.0/1", "_10.0.0.0/8", "_2000::/3") to establish system routes without intalling CKR tunnels for those prefixes.
 Use "inetv4" to include the full list of IPv4 internet prefixes (excluding internal networks) for both CKR and system routes; use "\~inetv4" for CKR tunnels only without system routes.
 Use "inetv6" or "\~inetv6" similarly for IPv6 (expands to "2000::/3").
-The "!" prefix for exclusions applies to CKR ranges for both normal and "\~" prefixed includes. No "!inetv4" or "!inetv6" are supported.
+The "!" prefix for exclusions applies to CKR ranges for normal, "\~ "and "_" prefixed includes. No "!inetv4" or "!inetv6" are supported.
 
-Local text files (one CIDR or bare IP address per line) are supported via the exact `file:///absolute/path/to/list.txt` syntax used in the browser address bar (both Linux/UNIX and Windows `file:///C:/...` forms). The `~` or `!` prefix may appear immediately before `file:///` to apply the no-system-route or exclude behaviour to the whole list. Blank lines and lines beginning with `#` are ignored. Example:
+Local text files (one CIDR or bare IP address per line) are supported via the exact "file:///absolute/path/to/list.txt" syntax used in the browser address bar (both Linux/UNIX and Windows "file:///C:/..." forms). The `~` or `_` or `!` prefix may appear immediately before "file:///" to apply CKR without system route, system route without CKR, or exclude behaviour to the whole list. Blank lines and lines beginning with `#` are ignored. Example:
 ```toml
 [tunnel_routing.remote_subnets]
-"<NODE_A_KEY>" = ["10.99.0.1/32", "file:///home/user/list-allow.txt", "!file:///home/user/excludes.txt", "~file:///home/user/noroute.txt"]
+"<NODE_A_KEY>" = ["10.99.0.1/32", "file:///home/user/list-allow.txt", "~file:///home/user/noroute.txt", "_file:///home/user/nockr.txt", "!file:///home/user/excludes.txt"]
 ```
 
 ## Exit-Node Setup

--- a/docs/CKR.md
+++ b/docs/CKR.md
@@ -49,10 +49,10 @@ Use "inetv4" to include the full list of IPv4 internet prefixes (excluding inter
 Use "inetv6" or "\~inetv6" similarly for IPv6 (expands to "2000::/3").
 The "!" prefix for exclusions applies to CKR ranges for normal, "\~ "and "_" prefixed includes. No "!inetv4" or "!inetv6" are supported.
 
-Local text files (one CIDR or bare IP address per line) are supported via the exact "file:///absolute/path/to/list.txt" syntax used in the browser address bar (both Linux/UNIX and Windows "file:///C:/..." forms). The `~` or `_` or `!` prefix may appear immediately before "file:///" to apply CKR without system route, system route without CKR, or exclude behaviour to the whole list. Blank lines and lines beginning with `#` are ignored. Example:
+Text files with route lists (one CIDR or bare IP address per line) via HTTP(S) and, of course, similar local text files are supported via the exact "https://example.com/routelist.txt" and "file:///absolute/path/to/list.txt" syntax used in the browser address bar (both Linux/UNIX and Windows "file:///C:/..." forms). The "\~" or "_" or "!" prefix may appear immediately before "http://" or "file:///" to apply CKR without system route, system route without CKR, or exclude behaviour to the whole list. Blank lines and lines beginning with "#" are ignored when processing files. Example:
 ```toml
 [tunnel_routing.remote_subnets]
-"<NODE_A_KEY>" = ["10.99.0.1/32", "file:///home/user/list-allow.txt", "~file:///home/user/noroute.txt", "_file:///home/user/nockr.txt", "!file:///home/user/excludes.txt"]
+"<NODE_A_KEY>" = ["10.99.0.1/32", "file:///home/user/list-allow.txt", "~file:///home/user/noroute.txt", "_https://example.com/nockr.txt", "!http://[211:5c63:53ac:6ae6:6d7e:9d0:c14f:efb8]:8080/excludes.txt"]
 ```
 
 ## Exit-Node Setup

--- a/docs/CKR.md
+++ b/docs/CKR.md
@@ -48,6 +48,12 @@ Use "inetv4" to include the full list of IPv4 internet prefixes (excluding inter
 Use "inetv6" or "\~inetv6" similarly for IPv6 (expands to "2000::/3").
 The "!" prefix for exclusions applies to CKR ranges for both normal and "\~" prefixed includes. No "!inetv4" or "!inetv6" are supported.
 
+Local text files (one CIDR or bare IP address per line) are supported via the exact `file:///absolute/path/to/list.txt` syntax used in the browser address bar (both Linux/UNIX and Windows `file:///C:/...` forms). The `~` or `!` prefix may appear immediately before `file:///` to apply the no-system-route or exclude behaviour to the whole list. Blank lines and lines beginning with `#` are ignored. Example:
+```toml
+[tunnel_routing.remote_subnets]
+"<NODE_A_KEY>" = ["10.99.0.1/32", "file:///home/user/list-allow.txt", "!file:///home/user/excludes.txt", "~file:///home/user/noroute.txt"]
+```
+
 ## Exit-Node Setup
 
 This example shows how to route all internet traffic from a client through a VPS running Yggdrasil-ng with CKR.


### PR DESCRIPTION
This change makes it easy to use route lists for split tunnelling without third-party scripts, right now.

The order in which Yggdrasil-ng components are loaded had to be changed to add this feature. There is one useful advantage of changing the loading order of components. If there are an incredibly large number of CKRs and routes, this does not prevent you from connecting quickly to the Yggdrasil network. The network works straight away, whilst the CKRs and routes are added later.

Furthermore, changing the order in which components are loaded simplifies the future addition of the "yggdrasil addRoute/delRoute/replaceRoute" feature, the prospect of which is very appealing, as it will allow users to quickly switch gateways – either in full or in parts – without any downtime of the TUN interface during the switch. In turn, the availability of a feature such as "yggdrasil addRoute/delRoute/replaceRoute" will simplify the addition of an auto-update feature for text files, with subsequent changes to the CKR and system routes, likewise without any downtime for the TUN interface.